### PR TITLE
feat: filtro de filas de prioridades (#33)

### DIFF
--- a/src/features/nutritional/NutritionalDashboard.tsx
+++ b/src/features/nutritional/NutritionalDashboard.tsx
@@ -1,3 +1,8 @@
+/**
+ * NutritionalDashboard – Painel principal de acompanhamento nutricional.
+ * Integra filas de prioridade, badges de alerta e seletores Redux.
+ * Issue #33 – US-FE-06
+ */
 import { useMemo, useState } from "react";
 import {
   Tag,
@@ -15,12 +20,14 @@ import {
 import styled from "styled-components";
 
 import { useAppDispatch, useAppSelector } from "src/store";
+import { selectFila1, selectFila5 } from "src/store/selectors/nutritionalSelectors";
 import { FeatureService } from "src/services/FeatureService";
 import Feature from "src/models/Feature";
 import { PageHeader } from "src/styles/PageHeader.style";
 import { PageCard } from "styles/Utils.style";
 import {
   acknowledgePatient,
+  setFiltFila as setFiltFilaAction,
   NutritionalPatient,
   AlaType,
   AcknowledgedEntry,
@@ -252,10 +259,9 @@ function matchFila(
   _acknowledged: Record<number, AcknowledgedEntry>
 ): boolean {
   if (!filtFila || filtFila === "all") return true;
-  if (filtFila === "glim") return !p.glim_diag;
-  if (filtFila === "24h") return p.haval > 18 || !p.glim_diag;
-  if (filtFila === "desg") return p.glim_diag === "grave";
-  if (filtFila === "d7") return p.d7;
+  if (filtFila === "FILA1") return (p.sev === "cr" || p.sev === "al") && p.haval > 18;
+  if (filtFila === "FILA2") return p.haval > 18;
+  if (filtFila === "FILA5") return p.d7 === true;
   return true;
 }
 
@@ -263,16 +269,18 @@ function matchFila(
 
 export function NutritionalDashboard() {
   const dispatch = useAppDispatch();
-  const { patients, acknowledged } = useAppSelector(
+  const { patients, acknowledged, filtFila } = useAppSelector(
     (state: any) => state.nutritional
   );
 
   const [viewMode, setViewMode] = useState<"grid" | "lista">("grid");
   const [filtAla, setFiltAla] = useState("all");
   const [filtSev, setFiltSev] = useState("");
-  const [filtFila, setFiltFila] = useState("");
   const [sortAsc, setSortAsc] = useState(false);
   const [modalPatient, setModalPatient] = useState<NutritionalPatient | null>(null);
+
+  const fila1Patients = useAppSelector(selectFila1);
+  const fila5Patients = useAppSelector(selectFila5);
   const [modalTab, setModalTab] = useState("vis");
 
   // ── Filtered + sorted list ──────────────────────────────────────────────
@@ -368,10 +376,15 @@ export function NutritionalDashboard() {
         filtAla={filtAla}
         filtSev={filtSev}
         filtFila={filtFila}
+        countsFila={{
+          FILA1: fila1Patients.length,
+          FILA2: patients.filter((p: NutritionalPatient) => p.haval > 18).length,
+          FILA5: fila5Patients.length,
+        }}
         sortAsc={sortAsc}
         onAlaChange={setFiltAla}
         onSevChange={setFiltSev}
-        onFilaChange={setFiltFila}
+        onFilaChange={(val) => dispatch(setFiltFilaAction(val))}
         onSortToggle={() => setSortAsc((v) => !v)}
       />
 
@@ -392,7 +405,7 @@ export function NutritionalDashboard() {
             $clickable={!!sev}
             onClick={() => {
               if (sev) {
-                setFiltFila("");
+                dispatch(setFiltFilaAction(""));
                 setFiltSev(filtSev === sev ? "" : sev);
               }
             }}
@@ -511,8 +524,8 @@ export function NutritionalDashboard() {
                       p.haval > 48
                         ? "#c41e3a"
                         : p.haval > 24
-                        ? "#d4931a"
-                        : "#3a9c6e";
+                          ? "#d4931a"
+                          : "#3a9c6e";
 
                     const instTags = p.inst.slice(0, 3);
                     const instMore = p.inst.length > 3 ? p.inst.length - 3 : 0;
@@ -586,6 +599,20 @@ export function NutritionalDashboard() {
                             <div style={{ fontSize: 11, color: "#8c8c8c" }}>
                               {FeatureService.has(Feature.HIDE_NAMES) ? "**a" : `${p.idade}a`} · {p.dias}d · #{p.pri} fila
                             </div>
+                            {(p.dados_incompletos || p.nrs_completo === false) && (
+                              <div style={{ marginTop: 6, display: "flex", flexDirection: "column", gap: 4, alignItems: "flex-start" }}>
+                                {p.dados_incompletos && (
+                                  <span style={{ display: "inline-block", padding: "1px 5px", borderRadius: "9px", fontSize: "9px", fontWeight: 600, background: "#fffbe6", color: "#d48806", border: "1px solid #ffe58f" }}>
+                                    ⚠️ APACHE/SOFA necessários
+                                  </span>
+                                )}
+                                {p.nrs_completo === false && (
+                                  <span style={{ display: "inline-block", padding: "1px 5px", borderRadius: "9px", fontSize: "9px", fontWeight: 600, background: "#fff1f0", color: "#cf1322", border: "1px solid #ffa39e" }}>
+                                    ❌ Pontuação incompleta
+                                  </span>
+                                )}
+                              </div>
+                            )}
                           </ListCell>
 
                           {/* Campo 1 · Risco */}
@@ -611,8 +638,8 @@ export function NutritionalDashboard() {
                                     p.glim_diag === "grave"
                                       ? "#7f0d1f"
                                       : p.glim_diag === "mod"
-                                      ? "#a32d2d"
-                                      : "#3a9c6e",
+                                        ? "#a32d2d"
+                                        : "#3a9c6e",
                                   fontWeight: 500,
                                 }}
                               >
@@ -637,8 +664,8 @@ export function NutritionalDashboard() {
                                     item.t === "lab"
                                       ? { bg: "#fcebeb", color: "#a32d2d", border: "#f09595" }
                                       : item.t === "clin"
-                                      ? { bg: "#fdf3dc", color: "#b7770d", border: "#fac775" }
-                                      : { bg: "#f0eeff", color: "#3c3489", border: "#b39ddb" };
+                                        ? { bg: "#fdf3dc", color: "#b7770d", border: "#fac775" }
+                                        : { bg: "#f0eeff", color: "#3c3489", border: "#b39ddb" };
                                   return (
                                     <Tooltip key={i} title={item.d}>
                                       <InlineBadge

--- a/src/features/nutritional/NutritionalFilter.tsx
+++ b/src/features/nutritional/NutritionalFilter.tsx
@@ -1,3 +1,8 @@
+/**
+ * NutritionalFilter – Barra de filtros do Painel Nutricional.
+ * Contém os seletores de Ala, Fila de prioridade (1, 2 e 5) e Risco.
+ * Issue #33 – US-FE-06
+ */
 import { Affix } from "antd";
 import { useState } from "react";
 import {
@@ -106,10 +111,9 @@ const ALA_COLORS: Record<AlaType, string> = {
 };
 
 const FILA_BTNS = [
-  { key: "glim", label: "GLIM pendente" },
-  { key: "24h", label: "Avaliar 24h" },
-  { key: "desg", label: "Desnut. grave" },
-  { key: "d7", label: "D7 pendente" },
+  { key: "FILA1", label: "Alta Prioridade" },
+  { key: "FILA2", label: "Avaliar 24h" },
+  { key: "FILA5", label: "D7 pendente" },
 ];
 
 const RISCO_BTNS = [
@@ -123,6 +127,7 @@ interface NutritionalFilterProps {
   filtAla: string;
   filtSev: string;
   filtFila: string;
+  countsFila: Record<string, number>;
   sortAsc: boolean;
   onAlaChange: (ala: string) => void;
   onSevChange: (sev: string) => void;
@@ -134,6 +139,7 @@ export function NutritionalFilter({
   filtAla,
   filtSev,
   filtFila,
+  countsFila,
   sortAsc,
   onAlaChange,
   onSevChange,
@@ -190,6 +196,17 @@ export function NutritionalFilter({
               onClick={() => handleFilaClick(key)}
             >
               {label}
+              <span style={{
+                background: filtFila === key ? '#7e57c2' : '#e0e0e0',
+                color: filtFila === key ? '#fff' : '#696766',
+                borderRadius: '10px',
+                padding: '1px 6px',
+                fontSize: '10px',
+                marginLeft: '6px',
+                fontWeight: 'bold'
+              }}>
+                {countsFila[key] || 0}
+              </span>
             </FilterBtn>
           ))}
         </FilterGroup>

--- a/src/features/nutritional/NutritionalSlice.ts
+++ b/src/features/nutritional/NutritionalSlice.ts
@@ -1,3 +1,8 @@
+/**
+ * NutritionalSlice – Estado global Redux para o módulo de nutrição.
+ * Gerencia pacientes, filtros de fila e dados de acompanhamento.
+ * Issue #33 – US-FE-06
+ */
 import { createSlice } from "@reduxjs/toolkit";
 
 export type AlaType = "UTI" | "B" | "C";
@@ -51,6 +56,8 @@ export interface NutritionalPatient {
   alergia: string | null;
   alOk: boolean;
   d7: boolean;
+  dados_incompletos?: boolean;
+  nrs_completo?: boolean;
   hist: HistEntry[];
 }
 
@@ -62,6 +69,7 @@ export interface AcknowledgedEntry {
 interface NutritionalState {
   patients: NutritionalPatient[];
   acknowledged: Record<number, AcknowledgedEntry>;
+  filtFila: string;
 }
 
 const MOCK_PATIENTS: NutritionalPatient[] = [
@@ -200,6 +208,8 @@ const MOCK_PATIENTS: NutritionalPatient[] = [
     alergia: null,
     alOk: true,
     d7: false,
+    dados_incompletos: true,
+    nrs_completo: false,
     hist: [],
   },
   {
@@ -257,7 +267,7 @@ const MOCK_PATIENTS: NutritionalPatient[] = [
     npo: 0,
     peso: "88kg",
     imc: 26.3,
-    haval: 14,
+    haval: 30,
     glim_diag: "nd",
     glim_fen: [],
     glim_etiol: [],
@@ -300,6 +310,7 @@ const MOCK_PATIENTS: NutritionalPatient[] = [
 const initialState: NutritionalState = {
   patients: MOCK_PATIENTS,
   acknowledged: {},
+  filtFila: "",
 };
 
 const nutritionalSlice = createSlice({
@@ -377,6 +388,9 @@ const nutritionalSlice = createSlice({
         patient.inst = patient.inst.filter((i) => !i.d.includes("Alergia"));
       }
     },
+    setFiltFila(state, action: { payload: string }) {
+      state.filtFila = action.payload;
+    },
     reset() {
       return { ...initialState, acknowledged: {} };
     },
@@ -389,6 +403,7 @@ export const {
   saveAval,
   confirmAllergy,
   acknowledgePatient,
+  setFiltFila,
   reset,
 } = nutritionalSlice.actions;
 export default nutritionalSlice.reducer;

--- a/src/features/nutritional/components/PatientCard.tsx
+++ b/src/features/nutritional/components/PatientCard.tsx
@@ -206,10 +206,10 @@ export function PatientCard({
     p.glim_diag === "grave"
       ? "#7f0d1f"
       : p.glim_diag === "mod"
-      ? "#a32d2d"
-      : p.glim_diag === "nd"
-      ? "#3a9c6e"
-      : "#d4931a";
+        ? "#a32d2d"
+        : p.glim_diag === "nd"
+          ? "#3a9c6e"
+          : "#d4931a";
 
   const instSlice = p.inst.slice(0, 3);
   const instMore = p.inst.length > 3 ? p.inst.length - 3 : 0;
@@ -251,6 +251,20 @@ export function PatientCard({
         </PatientName>
         <PatientMeta>
           {FeatureService.has(Feature.HIDE_NAMES) ? "**a" : `${p.idade}a`} · {p.dias}d · #{p.pri}
+          {(p.dados_incompletos || p.nrs_completo === false) && (
+            <div style={{ marginTop: 6, display: "flex", flexDirection: "column", gap: 4, alignItems: "flex-start" }}>
+              {p.dados_incompletos && (
+                <Badge $bg="#fffbe6" $color="#d48806" $border="#ffe58f">
+                  ⚠️ APACHE/SOFA necessários
+                </Badge>
+              )}
+              {p.nrs_completo === false && (
+                <Badge $bg="#fff1f0" $color="#cf1322" $border="#ffa39e">
+                  ❌ Pontuação incompleta
+                </Badge>
+              )}
+            </div>
+          )}
         </PatientMeta>
 
         {/* Campo 1 – Risco nutricional */}

--- a/src/store/selectors/nutritionalSelectors.ts
+++ b/src/store/selectors/nutritionalSelectors.ts
@@ -1,0 +1,20 @@
+/**
+ * Seletores Redux para filtragem de filas de prioridade nutricional.
+ * selectFila1: pacientes críticos/altos com avaliação atrasada (>18h).
+ * selectFila5: pacientes com flag D7 ativa.
+ * Issue #33 – US-FE-06
+ */
+import { createSelector } from '@reduxjs/toolkit';
+import { IRootState } from '../index';
+
+export const selectFila1 = createSelector(
+    (s: IRootState) => s.nutritional.patients,
+    (patients) => patients.filter(p =>
+        (p.sev === 'cr' || p.sev === 'al') && (p.haval ?? 0) > 18
+    )
+);
+
+export const selectFila5 = createSelector(
+    (s: IRootState) => s.nutritional.patients,
+    (patients) => patients.filter(p => p.d7 === true)
+);


### PR DESCRIPTION
📝 **Descrição**
Implementação do Painel Nutricional das Filas de Prioridades (1, 2 e 5) e integração de badges de sinalização visual para avaliações NRS e GLIM pendentes, obedecendo aos critérios de leilão documentados na Epic de Nutrição.

#33

🚀 **O que foi feito?**

- Filtro de Filas Customizado: Os seletores do topo agora usam nativamente o State Persistente do Redux para manter selecionadas as filas "Alta Prioridade" (Fila 1), "Avaliar 24h" (Fila 2) e "D7 Pendente" (Fila 5).
- Integração com Selectors: A lógica de filtragem foi componentizada rodando os selectFila1 e selectFila5 do arquivo nutritionalSelectors.ts para contabilizar os números em tempo real nos botões.
- Sinalização Visual no Card / Lista:


    1.   Adicionada condicional que renderiza badge amarela ⚠️ APACHE/SOFA necessários baseada na flag dados_incompletos.
    2.   Adicionada condicional que renderiza badge vermelha ❌ Pontuação incompleta ativada por nrs_completo = false.

-  Refatoração Mocks & Testes:

   1.  Adicionado cobertura mock em cima do NutritionalSlice.ts para testagem em dev e desassociação segura entre a Fila 1 e Fila 2 na listagem simulada.