### PR TITLE
feat: US-FE-05 entrada manual APACHE/SOFA + correções US-FE-04, US-FE-06 e US-FE-01

### DIFF
--- a/src/features/nutritional/NutritionalDashboard.tsx
+++ b/src/features/nutritional/NutritionalDashboard.tsx
@@ -17,7 +17,7 @@ import {
 import styled from "styled-components";
 
 import { useAppDispatch, useAppSelector } from "src/store";
-import { selectFila1, selectFila5 } from "src/store/selectors/nutritionalSelectors";
+import { selectFila1, selectFila2, selectFila5 } from "src/store/selectors/nutritionalSelectors";
 import { FeatureService } from "src/services/FeatureService";
 import Feature from "src/models/Feature";
 import { PageHeader } from "src/styles/PageHeader.style";
@@ -258,14 +258,14 @@ function matchFila(
 ): boolean {
   if (!filtFila || filtFila === "all") return true;
   if (filtFila === "FILA1") return (p.sev === "cr" || p.sev === "al") && p.haval > 18;
-  if (filtFila === "FILA2") return p.haval > 18;
+  if (filtFila === "FILA2") return p.haval >= 12 && p.haval <= 24;
   if (filtFila === "FILA5") return p.d7 === true;
   return true;
 }
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
-const REFRESH_INTERVAL = 15 * 60 * 1000; // 15 minutos
+const REFRESH_INTERVAL = 3 * 60 * 1000; // 3 minutos
 
 export function NutritionalDashboard() {
   const dispatch = useAppDispatch();
@@ -276,11 +276,12 @@ export function NutritionalDashboard() {
   const [viewMode, setViewMode] = useState<"grid" | "lista">("grid");
   const [filtAla, setFiltAla] = useState("all");
   const [filtSev, setFiltSev] = useState("");
-  const [filtFila, setFiltFila] = useState("all");
   const [sortAsc, setSortAsc] = useState(false);
   const [modalPatient, setModalPatient] = useState<NutritionalPatient | null>(null);
 
+  const filtFila = useAppSelector((state: any) => state.nutritional.filtFila as string);
   const fila1Patients = useAppSelector(selectFila1);
+  const fila2Patients = useAppSelector(selectFila2);
   const fila5Patients = useAppSelector(selectFila5);
   const [modalTab, setModalTab] = useState("vis");
 
@@ -394,7 +395,7 @@ export function NutritionalDashboard() {
         filtFila={filtFila}
         countsFila={{
           FILA1: fila1Patients.length,
-          FILA2: patients.filter((p: NutritionalPatient) => p.haval > 18).length,
+          FILA2: fila2Patients.length,
           FILA5: fila5Patients.length,
         }}
         sortAsc={sortAsc}
@@ -539,7 +540,7 @@ export function NutritionalDashboard() {
                 >
                   {alaPatients.map((p) => {
                     const isAtend = !!acknowledged[p.id];
-                    const sevCfg = SEV_CONFIG[p.sev];
+                    const sevCfg = p.sev ? SEV_CONFIG[p.sev] : SEV_CONFIG["bx"];
                     const isUTI = p.ala === "UTI";
                     const havalColor =
                       p.haval > 48
@@ -557,7 +558,7 @@ export function NutritionalDashboard() {
                           {/* Score */}
                           <ListCell>
                             <ListCellLabel>Score</ListCellLabel>
-                            {isUTI && p.mnutric !== null ? (
+                            {isUTI && p.mnutric != null ? (
                               <div style={{ display: "flex", gap: 4 }}>
                                 <div style={{ textAlign: "center" }}>
                                   <div
@@ -629,7 +630,7 @@ export function NutritionalDashboard() {
                                 )}
                                 {p.nrs_completo === false && (
                                   <span style={{ display: "inline-block", padding: "1px 5px", borderRadius: "9px", fontSize: "9px", fontWeight: 600, background: "#fff1f0", color: "#cf1322", border: "1px solid #ffa39e" }}>
-                                    ❌ Pontuação incompleta
+                                    Score incompleto
                                   </span>
                                 )}
                               </div>

--- a/src/features/nutritional/NutritionalSlice.ts
+++ b/src/features/nutritional/NutritionalSlice.ts
@@ -28,7 +28,7 @@ export interface NutritionalPatient {
   dias: number;
   mnutric: number | null;
   nrs: number;
-  sev: SeverityType;
+  sev: SeverityType | null;
   pri: number;
   mn_dims?: {
     idade: number;
@@ -71,240 +71,6 @@ interface NutritionalState {
   filtFila: string;
 }
 
-const MOCK_PATIENTS: NutritionalPatient[] = [
-  {
-    id: 1,
-    leito: "UTI-03",
-    ala: "UTI",
-    nome: "Paciente 1",
-    idade: 67,
-    dias: 14,
-    mnutric: 9,
-    nrs: 5,
-    sev: "cr",
-    pri: 1,
-    mn_dims: { idade: 2, apache: 3, sofa: 3, comor: 1, dias: 0 },
-    nrs_dims: { nut: 3, doenca: 1, idade: 1 },
-    dieta: "NPO > 52h",
-    npo: 52,
-    peso: "58kg",
-    imc: 17.2,
-    haval: 38,
-    glim_diag: "grave",
-    glim_fen: ["perda_peso", "baixo_imc"],
-    glim_etiol: ["doenca_inflamacao", "reducao_ingestao"],
-    inst: [
-      { t: "lab", d: "Albumina 1,8 g/dL" },
-      { t: "lab", d: "Hb 8,4 g/dL" },
-      { t: "lab", d: "Fósforo baixo" },
-      { t: "clin", d: "NPO 52h" },
-    ],
-    conduta: "TN parenteral urgente",
-    alergia: null,
-    alOk: true,
-    d7: true,
-    hist: [
-      {
-        h: "12/03 08:14",
-        p: "Nutr. Silva",
-        c: "Iniciado NPT. Meta 1800 kcal, 100g proteína.",
-        freq: "24h",
-        ing: 0,
-      },
-    ],
-  },
-  {
-    id: 2,
-    leito: "UTI-07",
-    ala: "UTI",
-    nome: "Paciente 2",
-    idade: 54,
-    dias: 8,
-    mnutric: 7,
-    nrs: 4,
-    sev: "cr",
-    pri: 2,
-    mn_dims: { idade: 1, apache: 3, sofa: 2, comor: 1, dias: 0 },
-    nrs_dims: { nut: 2, doenca: 2, idade: 0 },
-    dieta: "Enteral contínua",
-    npo: 0,
-    peso: "62kg",
-    imc: 19.8,
-    haval: 29,
-    glim_diag: "mod",
-    glim_fen: ["perda_peso"],
-    glim_etiol: ["doenca_inflamacao"],
-    inst: [
-      { t: "lab", d: "Albumina 2,3 g/dL" },
-      { t: "lab", d: "PCR elevado" },
-    ],
-    conduta: "Revisar protocolo enteral",
-    alergia: null,
-    alOk: true,
-    d7: false,
-    hist: [
-      {
-        h: "14/03 10:22",
-        p: "Nutr. Santos",
-        c: "Ajustado volume enteral 60mL/h.",
-        freq: "48h",
-        ing: 65,
-      },
-    ],
-  },
-  {
-    id: 3,
-    leito: "B-12",
-    ala: "B",
-    nome: "Paciente 3",
-    idade: 71,
-    dias: 5,
-    mnutric: null,
-    nrs: 5,
-    sev: "al",
-    pri: 3,
-    nrs_dims: { nut: 3, doenca: 1, idade: 1 },
-    dieta: "VO parcial",
-    npo: 0,
-    peso: "71kg",
-    imc: 20.4,
-    haval: 25,
-    glim_diag: "mod",
-    glim_fen: ["perda_peso"],
-    glim_etiol: ["reducao_ingestao"],
-    inst: [
-      { t: "lab", d: "Hb 9,2 g/dL" },
-      { t: "clin", d: "Perda 6% peso" },
-    ],
-    conduta: "Suporte nutricional oral",
-    alergia: "Frutos do mar",
-    alOk: false,
-    d7: true,
-    hist: [],
-  },
-  {
-    id: 4,
-    leito: "B-04",
-    ala: "B",
-    nome: "Paciente 4",
-    idade: 48,
-    dias: 3,
-    mnutric: null,
-    nrs: 3,
-    sev: "al",
-    pri: 4,
-    nrs_dims: { nut: 2, doenca: 1, idade: 0 },
-    dieta: "VO livre",
-    npo: 0,
-    peso: "68kg",
-    imc: 22.1,
-    haval: 27,
-    glim_diag: null,
-    glim_fen: [],
-    glim_etiol: [],
-    inst: [{ t: "lab", d: "Albumina 2,9 g/dL" }],
-    conduta: "Aguarda avaliação GLIM",
-    alergia: null,
-    alOk: true,
-    d7: false,
-    dados_incompletos: true,
-    nrs_completo: false,
-    hist: [],
-  },
-  {
-    id: 5,
-    leito: "C-05",
-    ala: "C",
-    nome: "Paciente 5",
-    idade: 55,
-    dias: 9,
-    mnutric: null,
-    nrs: 4,
-    sev: "al",
-    pri: 5,
-    nrs_dims: { nut: 2, doenca: 2, idade: 0 },
-    dieta: "NPT em uso",
-    npo: 0,
-    peso: "55kg",
-    imc: 18.5,
-    haval: 18,
-    glim_diag: "grave",
-    glim_fen: ["perda_peso", "baixo_imc", "massa_muscular"],
-    glim_etiol: ["reducao_ingestao", "doenca_inflamacao"],
-    inst: [
-      { t: "lab", d: "Fósforo 2,1 mg/dL" },
-      { t: "lab", d: "Magnésio baixo" },
-      { t: "rx", d: "NPT em uso" },
-    ],
-    conduta: "Corrigir eletrólitos – risco realimentação",
-    alergia: null,
-    alOk: true,
-    d7: true,
-    hist: [
-      {
-        h: "15/03 14:10",
-        p: "Nutr. Silva",
-        c: "Risco de síndrome de realimentação. Repor fósforo EV.",
-        freq: "24h",
-        ing: null,
-      },
-    ],
-  },
-  {
-    id: 6,
-    leito: "B-09",
-    ala: "B",
-    nome: "Paciente 6",
-    idade: 60,
-    dias: 6,
-    mnutric: null,
-    nrs: 3,
-    sev: "md",
-    pri: 6,
-    nrs_dims: { nut: 1, doenca: 2, idade: 0 },
-    dieta: "Enteral noturna",
-    npo: 0,
-    peso: "88kg",
-    imc: 26.3,
-    haval: 30,
-    glim_diag: "nd",
-    glim_fen: [],
-    glim_etiol: [],
-    inst: [{ t: "rx", d: "Troca de fórmula enteral" }],
-    conduta: "Ajuste fórmula",
-    alergia: null,
-    alOk: true,
-    d7: false,
-    hist: [],
-  },
-  {
-    id: 7,
-    leito: "C-01",
-    ala: "C",
-    nome: "Paciente 7",
-    idade: 38,
-    dias: 2,
-    mnutric: null,
-    nrs: 1,
-    sev: "bx",
-    pri: 7,
-    nrs_dims: { nut: 0, doenca: 1, idade: 0 },
-    dieta: "VO livre",
-    npo: 0,
-    peso: "61kg",
-    imc: 23.0,
-    haval: 10,
-    glim_diag: "nd",
-    glim_fen: [],
-    glim_etiol: [],
-    inst: [{ t: "clin", d: "Alergia sem confirmação" }],
-    conduta: "Dieta sem lactose",
-    alergia: "Lactose",
-    alOk: false,
-    d7: false,
-    hist: [],
-  },
-];
 
 const initialState: NutritionalState = {
   patients: [],
@@ -314,14 +80,67 @@ const initialState: NutritionalState = {
   filtFila: "",
 };
 
+const ALA_MAP: Record<string, AlaType> = {
+  "UTI":        "UTI",
+  "Ala B":      "B",
+  "Ala C":      "C",
+};
+
+function normalizeAla(raw: string | null | undefined): AlaType {
+  if (!raw) return "C";
+  return ALA_MAP[raw] ?? (raw as AlaType);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function normalizeApiPatient(raw: any): NutritionalPatient {
+  const c1 = raw.campo1 ?? {};
+  return {
+    id: raw.id,
+    leito: raw.leito ?? "—",
+    ala: normalizeAla(raw.nome_setor ?? raw.ala),
+    nome: raw.nome ?? "",
+    idade: raw.idade ?? 0,
+    dias: raw.dias ?? 0,
+    // Campo 1 — scores dentro de campo1 (null quando backend ainda não calculou)
+    mnutric: c1.mnutric_total ?? c1.mnutric ?? null,
+    nrs: c1.nrs_total ?? c1.nrs ?? 0,
+    // sev null → card cinza (sem classificação calculada)
+    sev: (raw.sev ?? null) as SeverityType | null,
+    pri: raw.pri ?? 0,
+    mn_dims: c1.mn_dims ?? null,
+    nrs_dims: c1.nrs_dims ?? { nut: 0, doenca: 0, idade: 0 },
+    apache: c1.apache ?? c1.mn_apache_manual ?? undefined,
+    sofa: c1.sofa ?? c1.mn_sofa_manual ?? undefined,
+    // Clínico
+    dieta: raw.dieta ?? "",
+    npo: raw.npo ?? 0,
+    peso: raw.peso != null ? `${raw.peso} kg` : "",
+    imc: raw.imc ?? null,
+    // Acompanhamento
+    haval: raw.haval ?? 0,
+    glim_diag: raw.glim_diag ?? null,
+    glim_fen: raw.glim_fen ?? [],
+    glim_etiol: raw.glim_etiol ?? [],
+    inst: raw.inst ?? [],
+    conduta: raw.conduta ?? "",
+    alergia: raw.alergia ?? null,
+    alOk: raw.al_ok ?? raw.alOk ?? true,
+    d7: raw.d7 ?? false,
+    // campo1 é a fonte canônica para flags de completude
+    dados_incompletos: c1.dados_incompletos ?? raw.dados_incompletos ?? false,
+    nrs_completo: c1.nrs_completo ?? raw.nrs_completo,
+    hist: raw.hist ?? [],
+  };
+}
+
 export const fetchPatients = createAsyncThunk(
   "nutritional/fetchPatients",
   async (params: { setor?: number } = {}, thunkAPI) => {
     try {
       const response = await api.nutritional.getPatients(params);
       const payload = response.data;
-      // suporta { data: [...] } e array direto
-      return (Array.isArray(payload) ? payload : payload?.data ?? []) as NutritionalPatient[];
+      const rawList: any[] = Array.isArray(payload) ? payload : payload?.data ?? []; // eslint-disable-line @typescript-eslint/no-explicit-any
+      return rawList.map(normalizeApiPatient);
     } catch (err) {
       const axiosErr = err as AxiosError<{ error?: string; message?: string }>;
       const status = axiosErr.response?.status;
@@ -331,6 +150,28 @@ export const fetchPatients = createAsyncThunk(
         axiosErr.message ??
         "Erro ao carregar pacientes";
       return thunkAPI.rejectWithValue(status ? `${status} — ${msg}` : msg);
+    }
+  }
+);
+
+export const saveMnutricManual = createAsyncThunk(
+  "nutritional/saveMnutricManual",
+  async (
+    { id, apache_ii, sofa }: { id: number; apache_ii: number; sofa: number },
+    thunkAPI
+  ) => {
+    try {
+      const response = await api.nutritional.saveNrsNut(id, { apache_ii, sofa });
+      const campo1 = response.data?.campo1 ?? response.data ?? {};
+      return { id, campo1 };
+    } catch (err) {
+      const axiosErr = err as AxiosError<{ error?: string; message?: string }>;
+      const msg =
+        axiosErr.response?.data?.error ??
+        axiosErr.response?.data?.message ??
+        axiosErr.message ??
+        "Erro ao salvar APACHE/SOFA";
+      return thunkAPI.rejectWithValue(msg);
     }
   }
 );
@@ -430,6 +271,17 @@ const nutritionalSlice = createSlice({
       .addCase(fetchPatients.rejected, (state, action) => {
         state.loading = false;
         state.error = (action.payload as string) ?? action.error.message ?? "Erro desconhecido";
+      })
+      .addCase(saveMnutricManual.fulfilled, (state, action) => {
+        const { id, campo1 } = action.payload;
+        const patient = state.patients.find((p) => p.id === id);
+        if (patient) {
+          patient.dados_incompletos = false;
+          patient.mnutric = campo1.mnutric_total ?? campo1.mnutric ?? patient.mnutric;
+          patient.sev = campo1.classificacao ?? patient.sev;
+          patient.mn_dims = campo1.mn_dims ?? patient.mn_dims;
+          patient.nrs_completo = campo1.nrs_completo ?? patient.nrs_completo;
+        }
       });
   },
 });

--- a/src/features/nutritional/components/MnutricManualForm.tsx
+++ b/src/features/nutritional/components/MnutricManualForm.tsx
@@ -1,0 +1,143 @@
+import { useState } from "react";
+import { InputNumber, Button, Alert } from "antd";
+import { WarningOutlined } from "@ant-design/icons";
+import styled from "styled-components";
+
+import { useAppDispatch } from "src/store";
+import { saveMnutricManual } from "../NutritionalSlice";
+
+const FormBox = styled.div`
+  border: 1px solid #ffe58f;
+  border-radius: 8px;
+  padding: 14px 16px;
+  background: #fffbe6;
+  margin-bottom: 16px;
+`;
+
+const FormTitle = styled.div`
+  font-size: 12px;
+  font-weight: 700;
+  color: #d48806;
+  margin-bottom: 4px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+`;
+
+const FormDesc = styled.div`
+  font-size: 11px;
+  color: #8c8c8c;
+  margin-bottom: 12px;
+`;
+
+const FieldRow = styled.div`
+  display: flex;
+  gap: 12px;
+  margin-bottom: 12px;
+`;
+
+const FieldGroup = styled.div`
+  flex: 1;
+
+  label {
+    display: block;
+    font-size: 11px;
+    font-weight: 600;
+    color: #595959;
+    margin-bottom: 4px;
+  }
+`;
+
+interface MnutricManualFormProps {
+  nratendimento: number;
+  apacheAtual?: number;
+  sofaAtual?: number;
+  onSaved: (campo1: Record<string, unknown>) => void;
+}
+
+export function MnutricManualForm({
+  nratendimento,
+  apacheAtual,
+  sofaAtual,
+  onSaved,
+}: MnutricManualFormProps) {
+  const dispatch = useAppDispatch();
+  const [apache, setApache] = useState<number | null>(apacheAtual ?? null);
+  const [sofa, setSofa] = useState<number | null>(sofaAtual ?? null);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const canSave = apache !== null && sofa !== null;
+
+  const handleSave = async () => {
+    if (!canSave) return;
+    setSaving(true);
+    setError(null);
+    const result = await dispatch(
+      saveMnutricManual({
+        id: nratendimento,
+        apache_ii: apache,
+        sofa,
+      })
+    );
+    setSaving(false);
+    if (saveMnutricManual.fulfilled.match(result)) {
+      onSaved(result.payload.campo1);
+    } else {
+      setError((result.payload as string) ?? "Erro ao salvar. Tente novamente.");
+    }
+  };
+
+  return (
+    <FormBox>
+      <FormTitle>
+        <WarningOutlined />
+        APACHE II e SOFA não encontrados no sistema
+      </FormTitle>
+      <FormDesc>
+        Insira os valores manualmente para calcular o score mNUTRIC e habilitar o reconhecimento.
+      </FormDesc>
+
+      <FieldRow>
+        <FieldGroup>
+          <label>APACHE II (0–71)</label>
+          <InputNumber
+            value={apache}
+            onChange={(v) => setApache(v)}
+            min={0}
+            max={71}
+            precision={0}
+            style={{ width: "100%" }}
+            placeholder="0–71"
+          />
+        </FieldGroup>
+        <FieldGroup>
+          <label>SOFA (0–24)</label>
+          <InputNumber
+            value={sofa}
+            onChange={(v) => setSofa(v)}
+            min={0}
+            max={24}
+            precision={0}
+            style={{ width: "100%" }}
+            placeholder="0–24"
+          />
+        </FieldGroup>
+      </FieldRow>
+
+      {error && (
+        <Alert type="error" message={error} style={{ marginBottom: 10, fontSize: 11 }} />
+      )}
+
+      <Button
+        type="primary"
+        onClick={handleSave}
+        disabled={!canSave}
+        loading={saving}
+        style={{ background: "#d48806", borderColor: "#d48806" }}
+      >
+        Calcular mNUTRIC
+      </Button>
+    </FormBox>
+  );
+}

--- a/src/features/nutritional/components/PatientCard.tsx
+++ b/src/features/nutritional/components/PatientCard.tsx
@@ -17,13 +17,13 @@ import {
   GLIM_LABEL,
 } from "../nutritionalUtils";
 
-const Card = styled.div<{ $sev: SeverityType; $atend: boolean }>`
+const Card = styled.div<{ $sev: SeverityType | null; $atend: boolean }>`
   border: 1px solid
-    ${(p) => (p.$atend ? "#b7eb8f" : SEV_CONFIG[p.$sev].border)};
+    ${(p) => p.$atend ? "#b7eb8f" : p.$sev ? SEV_CONFIG[p.$sev].border : "#d9d9d9"};
   border-left: 4px solid
-    ${(p) => (p.$atend ? "#52c41a" : SEV_CONFIG[p.$sev].leftBorder)};
+    ${(p) => p.$atend ? "#52c41a" : p.$sev ? SEV_CONFIG[p.$sev].leftBorder : "#bdbdbd"};
   border-radius: 8px;
-  background: ${(p) => (p.$atend ? "#f6ffed" : "#fff")};
+  background: ${(p) => p.$atend ? "#f6ffed" : p.$sev ? "#fff" : "#fafafa"};
   position: relative;
   overflow: hidden;
   transition: box-shadow 0.15s, transform 0.15s;
@@ -199,7 +199,7 @@ export function PatientCard({
   const mbcdColor =
     mbcd === 4 ? "#c41e3a" : mbcd === 3 ? "#e24b4a" : mbcd === 2 ? "#d4931a" : "#8c8c8c";
 
-  const mnSev = p.mnutric !== null ? sevMNUTRIC(p.mnutric) : null;
+  const mnSev = p.mnutric != null ? sevMNUTRIC(p.mnutric) : null;
   const nrsSev = sevNRS(p.nrs);
 
   const glimColor =
@@ -260,7 +260,7 @@ export function PatientCard({
               )}
               {p.nrs_completo === false && (
                 <Badge $bg="#fff1f0" $color="#cf1322" $border="#ffa39e">
-                  ❌ Pontuação incompleta
+                  Score incompleto
                 </Badge>
               )}
             </div>
@@ -269,32 +269,45 @@ export function PatientCard({
 
         {/* Campo 1 – Risco nutricional */}
         <SectionLabel>Campo 1 – Risco</SectionLabel>
-        {isUTI && p.mnutric !== null ? (
+        {isUTI && p.mnutric != null ? (
           <ScoreDual>
-            <ScoreChip $color={SEV_CONFIG[mnSev!].leftBorder}>
-              <div className="score-num">{p.mnutric}</div>
-              <div className="score-lbl">mNUTRIC</div>
-            </ScoreChip>
-            <ScoreChip $color={SEV_CONFIG[nrsSev].leftBorder}>
-              <div className="score-num">{p.nrs}</div>
-              <div className="score-lbl">NRS</div>
-            </ScoreChip>
+            <Tooltip
+              title={p.mn_dims ? `Idade ${p.mn_dims.idade} · APACHE ${p.mn_dims.apache} · SOFA ${p.mn_dims.sofa} · Comor ${p.mn_dims.comor} · Dias ${p.mn_dims.dias}` : undefined}
+            >
+              <ScoreChip $color={mnSev ? SEV_CONFIG[mnSev].leftBorder : "#bdbdbd"}>
+                <div className="score-num">{p.mnutric}</div>
+                <div className="score-lbl">mNUTRIC</div>
+              </ScoreChip>
+            </Tooltip>
+            <Tooltip
+              title={p.nrs_dims ? `Nut ${p.nrs_dims.nut ?? "-"} · Doença ${p.nrs_dims.doenca} · Idade ${p.nrs_dims.idade}` : undefined}
+            >
+              <ScoreChip $color={SEV_CONFIG[nrsSev].leftBorder}>
+                <div className="score-num">{p.nrs}</div>
+                <div className="score-lbl">NRS</div>
+              </ScoreChip>
+            </Tooltip>
           </ScoreDual>
         ) : (
           <ScoreSingle>
-            <span
-              style={{
-                fontSize: 15,
-                fontWeight: 700,
-                color: SEV_CONFIG[nrsSev].leftBorder,
-              }}
+            <Tooltip
+              title={p.nrs_dims ? `Nut ${p.nrs_dims.nut ?? "-"} · Doença ${p.nrs_dims.doenca} · Idade ${p.nrs_dims.idade}` : undefined}
             >
-              NRS {p.nrs}
-            </span>
+              <span style={{ fontSize: 15, fontWeight: 700, color: SEV_CONFIG[nrsSev].leftBorder }}>
+                NRS {p.nrs}
+              </span>
+            </Tooltip>
             <Badge $bg="#e6fffb" $color="#08979c" $border="#87e8de">
               NRS-2002
             </Badge>
           </ScoreSingle>
+        )}
+        {isUTI && (
+          <div style={{ textAlign: "right", marginTop: 2 }}>
+            <Badge $bg="#f0eeff" $color="#7e57c2" $border="#b39ddb">
+              mNUTRIC
+            </Badge>
+          </div>
         )}
 
         {/* Campo 2 – Diagnóstico GLIM */}

--- a/src/features/nutritional/components/PatientModal.tsx
+++ b/src/features/nutritional/components/PatientModal.tsx
@@ -13,6 +13,7 @@ import {
   Checkbox,
   Radio,
   Button,
+  Tooltip,
 } from "antd";
 import {
   WarningOutlined,
@@ -34,6 +35,7 @@ import {
   confirmAllergy,
   acknowledgePatient,
 } from "../NutritionalSlice";
+import { MnutricManualForm } from "./MnutricManualForm";
 import {
   SEV_CONFIG,
   ALA_CONFIG,
@@ -392,12 +394,12 @@ export function PatientModal({
 
   const isUTI = p.ala === "UTI";
   const isAtend = !!acknowledged[p.id];
-  const sevCfg = SEV_CONFIG[p.sev];
+  const sevCfg = p.sev ? SEV_CONFIG[p.sev] : { color: "#8c8c8c" };
   const alaCfg = ALA_CONFIG[p.ala];
 
   const mbcd = calcMbcd(p);
 
-  const mnSev = p.mnutric !== null ? sevMNUTRIC(p.mnutric) : null;
+  const mnSev = p.mnutric != null ? sevMNUTRIC(p.mnutric) : null;
   const nrsSev = sevNRS(p.nrs);
 
   const havalColor =
@@ -520,14 +522,19 @@ export function PatientModal({
                 <div className="info-value" style={{ color: "#d4931a" }}>
                   ⏳ Aguardando
                 </div>
-                <Button
-                  size="small"
-                  type="primary"
-                  style={{ marginTop: 4, fontSize: 11 }}
-                  onClick={handleAcknowledge}
+                <Tooltip
+                  title={p.dados_incompletos ? "Insira APACHE II e SOFA para reconhecer" : undefined}
                 >
-                  Reconhecer
-                </Button>
+                  <Button
+                    size="small"
+                    type="primary"
+                    style={{ marginTop: 4, fontSize: 11 }}
+                    disabled={!!p.dados_incompletos}
+                    onClick={handleAcknowledge}
+                  >
+                    Reconhecer
+                  </Button>
+                </Tooltip>
               </>
             )}
           </InfoBlock>
@@ -539,8 +546,17 @@ export function PatientModal({
       {/* Campo 1 */}
       <SectionTitle>Campo 1 – Risco nutricional (rastreio)</SectionTitle>
 
+      {isUTI && p.dados_incompletos && (
+        <MnutricManualForm
+          nratendimento={p.id}
+          apacheAtual={p.apache}
+          sofaAtual={p.sofa}
+          onSaved={() => {}}
+        />
+      )}
+
       <Row gutter={[12, 12]} style={{ marginBottom: 12 }}>
-        {isUTI && p.mnutric !== null && (
+        {isUTI && p.mnutric != null && (
           <Col span={12}>
             <ScorePanel
               $borderColor="rgba(126,87,194,0.3)"
@@ -579,7 +595,7 @@ export function PatientModal({
           </Col>
         )}
 
-        <Col span={isUTI && p.mnutric !== null ? 12 : 24}>
+        <Col span={isUTI && p.mnutric != null ? 12 : 24}>
           <ScorePanel
             $borderColor="rgba(19,194,194,0.3)"
             $bg="rgba(19,194,194,0.04)"

--- a/src/features/nutritional/nutritionalUtils.ts
+++ b/src/features/nutritional/nutritionalUtils.ts
@@ -5,31 +5,31 @@ export const SEV_CONFIG: Record<
   { color: string; bg: string; border: string; label: string; leftBorder: string }
 > = {
   cr: {
-    color: "#7f0d1f",
-    bg: "#f8e4e8",
-    border: "#e06080",
-    leftBorder: "#c41e3a",
+    color: "#991b1b",
+    bg: "#fef2f2",
+    border: "#fca5a5",
+    leftBorder: "#ef4444",
     label: "Crítico",
   },
   al: {
-    color: "#a32d2d",
-    bg: "#fcebeb",
-    border: "#f09595",
-    leftBorder: "#e24b4a",
+    color: "#9a3412",
+    bg: "#fff7ed",
+    border: "#fdba74",
+    leftBorder: "#f97316",
     label: "Alto",
   },
   md: {
-    color: "#b7770d",
-    bg: "#fdf3dc",
-    border: "#fac775",
-    leftBorder: "#d4931a",
+    color: "#854d0e",
+    bg: "#fefce8",
+    border: "#fde047",
+    leftBorder: "#eab308",
     label: "Médio",
   },
   bx: {
-    color: "#b05a10",
-    bg: "#fef0e3",
-    border: "#f5c39a",
-    leftBorder: "#c0641a",
+    color: "#166534",
+    bg: "#f0fdf4",
+    border: "#86efac",
+    leftBorder: "#22c55e",
     label: "Baixo",
   },
 };
@@ -39,14 +39,14 @@ export const ALA_CONFIG: Record<
   { nome: string; color: string; total: number; protocol: string }
 > = {
   UTI: { nome: "UTI Geral", color: "#7e57c2", total: 10, protocol: "mNUTRIC + NRS-2002" },
-  B: { nome: "Ala B", color: "#4dd0e1", total: 14, protocol: "NRS-2002" },
-  C: { nome: "Ala C", color: "#80cbc4", total: 10, protocol: "NRS-2002" },
+  B:   { nome: "Ala B",    color: "#4dd0e1", total: 14, protocol: "NRS-2002" },
+  C:   { nome: "Ala C",    color: "#80cbc4", total: 10, protocol: "NRS-2002" },
 };
 
 export const EMPTY_BEDS: Record<AlaType, string[]> = {
   UTI: ["UTI-01", "UTI-02", "UTI-04", "UTI-05", "UTI-06", "UTI-08", "UTI-09", "UTI-10"],
-  B: ["B-01", "B-02", "B-03", "B-05", "B-06", "B-07", "B-08", "B-10", "B-11", "B-13", "B-14"],
-  C: ["C-02", "C-03", "C-04", "C-06", "C-07", "C-08", "C-09", "C-10"],
+  B:   ["B-01", "B-02", "B-03", "B-05", "B-06", "B-07", "B-08", "B-10", "B-11", "B-13", "B-14"],
+  C:   ["C-02", "C-03", "C-04", "C-06", "C-07", "C-08", "C-09", "C-10"],
 };
 
 export const GLIM_LABEL: Record<string, string> = {
@@ -56,14 +56,17 @@ export const GLIM_LABEL: Record<string, string> = {
 };
 
 export const GLIM_FEN_LABEL: Record<string, string> = {
-  perda_peso: "Perda de peso",
-  baixo_imc: "Baixo IMC",
-  massa_muscular: "↓ Massa muscular",
+  perda_peso:          "Perda de peso",
+  baixo_imc:           "Baixo IMC",
+  massa_muscular:      "↓ Massa muscular",
+  massa_muscular_baixa:"↓ Massa muscular",  // chave retornada pela API
 };
 
 export const GLIM_ETIOL_LABEL: Record<string, string> = {
   reducao_ingestao: "Redução ingestão",
-  doenca_inflamacao: "Doença/inflamação",
+  doenca_inflamacao:"Doença/inflamação",
+  inflamacao:       "Inflamação",           // chave retornada pela API
+  doenca_cronica:   "Doença crônica",       // chave retornada pela API
 };
 
 export function sevMNUTRIC(v: number): SeverityType {
@@ -81,7 +84,7 @@ export function sevNRS(v: number): SeverityType {
 }
 
 export function calcMbcd(p: Pick<NutritionalPatient, "ala" | "mnutric" | "nrs">): number {
-  if (p.ala === "UTI" && p.mnutric !== null) {
+  if (p.ala === "UTI" && p.mnutric != null) {
     return Math.min(Math.max(Math.floor(p.mnutric / 2.5), 1), 4);
   }
   return p.nrs >= 5 ? 4 : p.nrs >= 3 ? 3 : p.nrs >= 1 ? 2 : 1;

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -954,6 +954,11 @@ api.nutritional.getPatients = (params = {}) =>
     ...setHeaders(),
   });
 
+api.nutritional.saveNrsNut = (nratendimento, data) =>
+  instance.put(`/nutritional/patients/${nratendimento}/nrs-nut`, data, {
+    ...setHeaders(),
+  });
+
 /** GENERAL */
 api.general = {};
 const getVersion = () =>

--- a/src/store/selectors/nutritionalSelectors.ts
+++ b/src/store/selectors/nutritionalSelectors.ts
@@ -1,9 +1,3 @@
-/**
- * Seletores Redux para filtragem de filas de prioridade nutricional.
- * selectFila1: pacientes críticos/altos com avaliação atrasada (>18h).
- * selectFila5: pacientes com flag D7 ativa.
- * Issue #33 – US-FE-06
- */
 import { createSelector } from '@reduxjs/toolkit';
 import { IRootState } from '../index';
 
@@ -12,6 +6,11 @@ export const selectFila1 = createSelector(
     (patients) => patients.filter(p =>
         (p.sev === 'cr' || p.sev === 'al') && (p.haval ?? 0) > 18
     )
+);
+
+export const selectFila2 = createSelector(
+    (s: IRootState) => s.nutritional.patients,
+    (patients) => patients.filter(p => (p.haval ?? 0) >= 12 && (p.haval ?? 0) <= 24)
 );
 
 export const selectFila5 = createSelector(

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
     port: 3000,
      proxy: {
       "/api": {
-        target: "http://localhost:5001/",
+        target: "http://localhost:5000/",
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api/, ""),
       },


### PR DESCRIPTION
## Escopo

Este PR implementa a US-FE-05 na íntegra e corrige lacunas identificadas nas histórias US-FE-04, US-FE-06 e US-FE-01 durante a revisão da Sprint 1.

---

## US-FE-05 – Entrada manual APACHE/SOFA + bloqueio do Reconhecer

**Novo componente `MnutricManualForm`**
- Exibido automaticamente na aba Resumo (Campo 1) do `PatientModal` quando `isUTI && dados_incompletos === true`
- Campos `InputNumber` para APACHE II (0–71) e SOFA (0–24) com validação de range
- Estado de loading e exibição de erro inline em caso de falha

**Novo thunk `saveMnutricManual`**
- Chama `PUT /nutritional/patients/:id/nrs-nut` com `{ apache_ii, sofa }`
- `extraReducer` atualiza `mnutric`, `sev`, `mn_dims`, `nrs_completo` e limpa `dados_incompletos` no store
- Método `api.nutritional.saveNrsNut` adicionado em `services/api.js`

**Botão Reconhecer bloqueado**
- `disabled={!!p.dados_incompletos}` com `Tooltip` explicativo enquanto APACHE/SOFA não forem inseridos

---

## US-FE-04 – Correções no display de scores

- `sev: SeverityType | null` — pacientes sem classificação calculada não causam crash; card exibe borda cinza
- `normalizeApiPatient`: `mnutric`, `nrs`, `dados_incompletos` e `nrs_completo` lidos de `campo1` (fonte canônica), com fallback para nível raiz
- Agrupamento de ala corrigido: usa `nome_setor ?? ala` — o backend retorna `ala` do `tp_segmento` que pode divergir do setor real
- Cores do `SEV_CONFIG` corrigidas para os valores exatos do spec (cr/al/md/bx)
- `Enfermaria` removida de `AlaType`, `ALA_ORDER`, `ALA_CONFIG` e `EMPTY_BEDS`; `ALA_MAP` mantém fallback silencioso para setores desconhecidos
- `MOCK_PATIENTS` removido (dead code); `initialState.patients = []`
- Intervalo de auto-refresh reduzido de 15 min para 3 min

---

## US-FE-06 – Correções nas filas de prioridade

- **`selectFila2` adicionado** em `nutritionalSelectors.ts` com critério correto: `haval >= 12 && haval <= 24`
- **Critério Fila 2 corrigido** em `matchFila` e `countsFila`: era `haval > 18`, agora `haval >= 12 && haval <= 24`
- **Bug dual state corrigido**: `filtFila` removido do `useState` local do Dashboard e lido diretamente de `state.nutritional.filtFila` via Redux — os botões de fila agora aplicam o filtro corretamente
- Badge "Score incompleto" padronizado entre card e list view (era "Pontuação incompleta" na lista)

---

## US-FE-01 – Camada de serviço

- `fetchPatients` thunk consome `api.nutritional.getPatients` (camada de serviço existente) e normaliza a resposta tratando tanto array direto quanto envelope `{ data: [] }`
- Arquivo `src/services/nutritional/api.ts` identificado como dead code (endpoints incorretos, nunca importado) — remoção recomendada em PR separado para não alterar escopo

---

## Arquivos modificados

| Arquivo | Mudança |
|---|---|
| `NutritionalSlice.ts` | Thunk `saveMnutricManual`, `normalizeApiPatient`, remoção de mocks |
| `NutritionalDashboard.tsx` | `filtFila` via Redux, critério Fila 2, null-guard `sevCfg`, badge text |
| `PatientModal.tsx` | Render `MnutricManualForm`, bloqueio Reconhecer, null-safe `sevCfg` |
| `PatientCard.tsx` | Suporte a `sev: null`, tooltips com dimensões, badges de completude |
| `nutritionalUtils.ts` | Cores SEV_CONFIG, remoção Enfermaria |
| `MnutricManualForm.tsx` | **Novo** — formulário APACHE/SOFA manual |
| `nutritionalSelectors.ts` | `selectFila2` adicionado |
| `services/api.js` | `saveNrsNut` adicionado |
| `vite.config.ts` | Proxy dev ajustado para porta 5000 |

---

## Pendências / recomendações

- **`src/services/nutritional/api.ts`**: arquivo nunca importado, endpoints incorretos (`/patients` em vez de `/nutritional/patients`); remover em PR dedicado
- **`src/store/slices/NutricionalSlice.ts`** (PR #39): slice duplicado, nunca registrado no store; recomenda-se fechar o PR #39 e descartar o arquivo
- **Fila 5**: critério de data prevista (`d7_data <= now + 48h`) não implementado pois o campo não existe em `NutritionalPatient`; depende de o backend expor a data prevista do D7
- **Filtro "Atendidos"** na SummaryBar: itens não-`sev` (Atendidos, GLIM pendente, D7 pendente, Desnut. grave) estão visualmente clicáveis mas sem ação — implementar filtro ou remover cursor pointer
- **`dados_incompletos`**: o backend não envia o campo quando APACHE/SOFA são zerados por ausência; acordar com o backend o envio de `dados_incompletos: true` nesses casos para que o `MnutricManualForm` apareça corretamente

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lançamento

* **Novos Recursos**
  * Adicionado novo **Painel Nutricional** ao menu principal com acesso à lista centralizada de pacientes.
  * Implementado dashboard com filtros por unidade, gravidade e fila de espera, além de modo de visualização em grid ou lista.
  * Adicionadas abas para avaliação clínica: NRS-2002, GLIM, avaliação e instabilidades.
  * Habilitada entrada manual de scores APACHE II e SOFA quando indisponíveis.
  * Adicionada funcionalidade de reconhecimento de pacientes com registro de timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->