### PR TITLE
Feat/us fe 11

### DIFF
--- a/src/features/nutritional/NutritionalSlice.ts
+++ b/src/features/nutritional/NutritionalSlice.ts
@@ -7,8 +7,10 @@ export type SeverityType = "cr" | "al" | "md" | "bx";
 export type GlimDiag = "nd" | "mod" | "grave" | null;
 
 export interface InstItem {
+  id: number;
   t: "lab" | "clin" | "rx";
   d: string;
+  ack: boolean;
 }
 
 export interface HistEntry {
@@ -69,6 +71,7 @@ interface NutritionalState {
   loading: boolean;
   error: string | null;
   filtFila: string;
+  alertasLoading: Record<number, boolean>;
 }
 
 
@@ -78,6 +81,7 @@ const initialState: NutritionalState = {
   loading: false,
   error: null,
   filtFila: "",
+  alertasLoading: {},
 };
 
 const ALA_MAP: Record<string, AlaType> = {
@@ -121,7 +125,12 @@ function normalizeApiPatient(raw: any): NutritionalPatient {
     glim_diag: raw.glim_diag ?? null,
     glim_fen: raw.glim_fen ?? [],
     glim_etiol: raw.glim_etiol ?? [],
-    inst: raw.inst ?? [],
+    inst: (raw.inst ?? []).map((i: any) => ({ // eslint-disable-line @typescript-eslint/no-explicit-any
+      id: i.id ?? 0,
+      t: i.t,
+      d: i.d,
+      ack: i.ack ?? false,
+    })),
     conduta: raw.conduta ?? "",
     alergia: raw.alergia ?? null,
     alOk: raw.al_ok ?? raw.alOk ?? true,
@@ -171,6 +180,52 @@ export const saveMnutricManual = createAsyncThunk(
         axiosErr.response?.data?.message ??
         axiosErr.message ??
         "Erro ao salvar APACHE/SOFA";
+      return thunkAPI.rejectWithValue(msg);
+    }
+  }
+);
+
+export const fetchAlertas = createAsyncThunk(
+  "nutritional/fetchAlertas",
+  async (patientId: number, thunkAPI) => {
+    try {
+      const response = await api.nutritional.getAlertas(patientId);
+      const raw: any[] = Array.isArray(response.data) ? response.data : response.data?.data ?? []; // eslint-disable-line @typescript-eslint/no-explicit-any
+      return {
+        patientId,
+        alertas: raw.map((i: any) => ({ id: i.id ?? 0, t: i.t, d: i.d, ack: i.ack ?? false })), // eslint-disable-line @typescript-eslint/no-explicit-any
+      };
+    } catch (err) {
+      const axiosErr = err as AxiosError<{ error?: string; message?: string }>;
+      const msg = axiosErr.response?.data?.error ?? axiosErr.response?.data?.message ?? axiosErr.message ?? "Erro ao carregar alertas";
+      return thunkAPI.rejectWithValue(msg);
+    }
+  }
+);
+
+export const acknowledgeAlert = createAsyncThunk(
+  "nutritional/acknowledgeAlert",
+  async ({ patientId, alertaId }: { patientId: number; alertaId: number }, thunkAPI) => {
+    try {
+      await api.nutritional.acknowledgeAlert(patientId, alertaId);
+      return { patientId, alertaId };
+    } catch (err) {
+      const axiosErr = err as AxiosError<{ error?: string; message?: string }>;
+      const msg = axiosErr.response?.data?.error ?? axiosErr.response?.data?.message ?? axiosErr.message ?? "Erro ao reconhecer alerta";
+      return thunkAPI.rejectWithValue(msg);
+    }
+  }
+);
+
+export const acknowledgeAllAlertas = createAsyncThunk(
+  "nutritional/acknowledgeAllAlertas",
+  async ({ patientId, alertaIds }: { patientId: number; alertaIds: number[] }, thunkAPI) => {
+    try {
+      await api.nutritional.acknowledgeAllAlertas(patientId);
+      return { patientId, alertaIds };
+    } catch (err) {
+      const axiosErr = err as AxiosError<{ error?: string; message?: string }>;
+      const msg = axiosErr.response?.data?.error ?? axiosErr.response?.data?.message ?? axiosErr.message ?? "Erro ao reconhecer alertas";
       return thunkAPI.rejectWithValue(msg);
     }
   }
@@ -243,6 +298,22 @@ const nutritionalSlice = createSlice({
         });
       }
     },
+    marcarAlertaReconhecido(state, action: { payload: { patientId: number; alertaId: number } }) {
+      const { patientId, alertaId } = action.payload;
+      const patient = state.patients.find((p) => p.id === patientId);
+      if (patient) {
+        const alerta = patient.inst.find((i) => i.id === alertaId);
+        if (alerta) alerta.ack = true;
+      }
+    },
+    reverterAlerta(state, action: { payload: { patientId: number; alertaId: number } }) {
+      const { patientId, alertaId } = action.payload;
+      const patient = state.patients.find((p) => p.id === patientId);
+      if (patient) {
+        const alerta = patient.inst.find((i) => i.id === alertaId);
+        if (alerta) alerta.ack = false;
+      }
+    },
     confirmAllergy(state, action: { payload: { id: number } }) {
       const { id } = action.payload;
       const patient = state.patients.find((p) => p.id === id);
@@ -272,6 +343,28 @@ const nutritionalSlice = createSlice({
         state.loading = false;
         state.error = (action.payload as string) ?? action.error.message ?? "Erro desconhecido";
       })
+      .addCase(fetchAlertas.pending, (state, action) => {
+        state.alertasLoading[action.meta.arg] = true;
+      })
+      .addCase(fetchAlertas.fulfilled, (state, action) => {
+        const { patientId, alertas } = action.payload;
+        state.alertasLoading[patientId] = false;
+        const patient = state.patients.find((p) => p.id === patientId);
+        if (patient) patient.inst = alertas;
+      })
+      .addCase(fetchAlertas.rejected, (state, action) => {
+        state.alertasLoading[action.meta.arg] = false;
+      })
+      .addCase(acknowledgeAllAlertas.fulfilled, (state, action) => {
+        const { patientId, alertaIds } = action.payload;
+        const patient = state.patients.find((p) => p.id === patientId);
+        if (patient) {
+          alertaIds.forEach((id) => {
+            const a = patient.inst.find((i) => i.id === id);
+            if (a) a.ack = true;
+          });
+        }
+      })
       .addCase(saveMnutricManual.fulfilled, (state, action) => {
         const { id, campo1 } = action.payload;
         const patient = state.patients.find((p) => p.id === id);
@@ -292,6 +385,8 @@ export const {
   saveAval,
   confirmAllergy,
   acknowledgePatient,
+  marcarAlertaReconhecido,
+  reverterAlerta,
   setFiltFila,
   reset,
 } = nutritionalSlice.actions;

--- a/src/features/nutritional/NutritionalSlice.ts
+++ b/src/features/nutritional/NutritionalSlice.ts
@@ -71,7 +71,7 @@ interface NutritionalState {
   loading: boolean;
   error: string | null;
   filtFila: string;
-  alertasLoading: Record<number, boolean>;
+  alertsLoading: Record<number, boolean>;
 }
 
 
@@ -81,7 +81,7 @@ const initialState: NutritionalState = {
   loading: false,
   error: null,
   filtFila: "",
-  alertasLoading: {},
+  alertsLoading: {},
 };
 
 const ALA_MAP: Record<string, AlaType> = {
@@ -185,19 +185,19 @@ export const saveMnutricManual = createAsyncThunk(
   }
 );
 
-export const fetchAlertas = createAsyncThunk(
-  "nutritional/fetchAlertas",
+export const fetchAlerts = createAsyncThunk(
+  "nutritional/fetchAlerts",
   async (patientId: number, thunkAPI) => {
     try {
-      const response = await api.nutritional.getAlertas(patientId);
+      const response = await api.nutritional.getAlerts(patientId);
       const raw: any[] = Array.isArray(response.data) ? response.data : response.data?.data ?? []; // eslint-disable-line @typescript-eslint/no-explicit-any
       return {
         patientId,
-        alertas: raw.map((i: any) => ({ id: i.id ?? 0, t: i.t, d: i.d, ack: i.ack ?? false })), // eslint-disable-line @typescript-eslint/no-explicit-any
+        alerts: raw.map((i: any) => ({ id: i.id ?? 0, t: i.t, d: i.d, ack: i.ack ?? false })), // eslint-disable-line @typescript-eslint/no-explicit-any
       };
     } catch (err) {
       const axiosErr = err as AxiosError<{ error?: string; message?: string }>;
-      const msg = axiosErr.response?.data?.error ?? axiosErr.response?.data?.message ?? axiosErr.message ?? "Erro ao carregar alertas";
+      const msg = axiosErr.response?.data?.error ?? axiosErr.response?.data?.message ?? axiosErr.message ?? "Error loading alerts";
       return thunkAPI.rejectWithValue(msg);
     }
   }
@@ -205,27 +205,13 @@ export const fetchAlertas = createAsyncThunk(
 
 export const acknowledgeAlert = createAsyncThunk(
   "nutritional/acknowledgeAlert",
-  async ({ patientId, alertaId }: { patientId: number; alertaId: number }, thunkAPI) => {
+  async ({ patientId, alertId }: { patientId: number; alertId: number }, thunkAPI) => {
     try {
-      await api.nutritional.acknowledgeAlert(patientId, alertaId);
-      return { patientId, alertaId };
+      await api.nutritional.acknowledgeAlert(patientId, alertId);
+      return { patientId, alertId };
     } catch (err) {
       const axiosErr = err as AxiosError<{ error?: string; message?: string }>;
-      const msg = axiosErr.response?.data?.error ?? axiosErr.response?.data?.message ?? axiosErr.message ?? "Erro ao reconhecer alerta";
-      return thunkAPI.rejectWithValue(msg);
-    }
-  }
-);
-
-export const acknowledgeAllAlertas = createAsyncThunk(
-  "nutritional/acknowledgeAllAlertas",
-  async ({ patientId, alertaIds }: { patientId: number; alertaIds: number[] }, thunkAPI) => {
-    try {
-      await api.nutritional.acknowledgeAllAlertas(patientId);
-      return { patientId, alertaIds };
-    } catch (err) {
-      const axiosErr = err as AxiosError<{ error?: string; message?: string }>;
-      const msg = axiosErr.response?.data?.error ?? axiosErr.response?.data?.message ?? axiosErr.message ?? "Erro ao reconhecer alertas";
+      const msg = axiosErr.response?.data?.error ?? axiosErr.response?.data?.message ?? axiosErr.message ?? "Error acknowledging alert";
       return thunkAPI.rejectWithValue(msg);
     }
   }
@@ -298,20 +284,20 @@ const nutritionalSlice = createSlice({
         });
       }
     },
-    marcarAlertaReconhecido(state, action: { payload: { patientId: number; alertaId: number } }) {
-      const { patientId, alertaId } = action.payload;
+    markAlertAcknowledged(state, action: { payload: { patientId: number; alertId: number } }) {
+      const { patientId, alertId } = action.payload;
       const patient = state.patients.find((p) => p.id === patientId);
       if (patient) {
-        const alerta = patient.inst.find((i) => i.id === alertaId);
-        if (alerta) alerta.ack = true;
+        const alert = patient.inst.find((i) => i.id === alertId);
+        if (alert) alert.ack = true;
       }
     },
-    reverterAlerta(state, action: { payload: { patientId: number; alertaId: number } }) {
-      const { patientId, alertaId } = action.payload;
+    revertAlert(state, action: { payload: { patientId: number; alertId: number } }) {
+      const { patientId, alertId } = action.payload;
       const patient = state.patients.find((p) => p.id === patientId);
       if (patient) {
-        const alerta = patient.inst.find((i) => i.id === alertaId);
-        if (alerta) alerta.ack = false;
+        const alert = patient.inst.find((i) => i.id === alertId);
+        if (alert) alert.ack = false;
       }
     },
     confirmAllergy(state, action: { payload: { id: number } }) {
@@ -343,27 +329,17 @@ const nutritionalSlice = createSlice({
         state.loading = false;
         state.error = (action.payload as string) ?? action.error.message ?? "Erro desconhecido";
       })
-      .addCase(fetchAlertas.pending, (state, action) => {
-        state.alertasLoading[action.meta.arg] = true;
+      .addCase(fetchAlerts.pending, (state, action) => {
+        state.alertsLoading[action.meta.arg] = true;
       })
-      .addCase(fetchAlertas.fulfilled, (state, action) => {
-        const { patientId, alertas } = action.payload;
-        state.alertasLoading[patientId] = false;
+      .addCase(fetchAlerts.fulfilled, (state, action) => {
+        const { patientId, alerts } = action.payload;
+        state.alertsLoading[patientId] = false;
         const patient = state.patients.find((p) => p.id === patientId);
-        if (patient) patient.inst = alertas;
+        if (patient) patient.inst = alerts;
       })
-      .addCase(fetchAlertas.rejected, (state, action) => {
-        state.alertasLoading[action.meta.arg] = false;
-      })
-      .addCase(acknowledgeAllAlertas.fulfilled, (state, action) => {
-        const { patientId, alertaIds } = action.payload;
-        const patient = state.patients.find((p) => p.id === patientId);
-        if (patient) {
-          alertaIds.forEach((id) => {
-            const a = patient.inst.find((i) => i.id === id);
-            if (a) a.ack = true;
-          });
-        }
+      .addCase(fetchAlerts.rejected, (state, action) => {
+        state.alertsLoading[action.meta.arg] = false;
       })
       .addCase(saveMnutricManual.fulfilled, (state, action) => {
         const { id, campo1 } = action.payload;
@@ -385,8 +361,8 @@ export const {
   saveAval,
   confirmAllergy,
   acknowledgePatient,
-  marcarAlertaReconhecido,
-  reverterAlerta,
+  markAlertAcknowledged,
+  revertAlert,
   setFiltFila,
   reset,
 } = nutritionalSlice.actions;

--- a/src/features/nutritional/NutritionalSlice.ts
+++ b/src/features/nutritional/NutritionalSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
 import { AxiosError } from "axios";
-import api from "services/api";
+import api, { instance, setHeaders } from "services/api";
 
 export type AlaType = "UTI" | "B" | "C";
 export type SeverityType = "cr" | "al" | "md" | "bx";
@@ -121,10 +121,10 @@ function normalizeApiPatient(raw: any): NutritionalPatient {
     peso: raw.peso != null ? `${raw.peso} kg` : "",
     imc: raw.imc ?? null,
     // Acompanhamento
-    haval: raw.haval ?? 0,
+    haval: raw.haval ?? 999,
     glim_diag: raw.glim_diag ?? null,
-    glim_fen: raw.glim_fen ?? [],
-    glim_etiol: raw.glim_etiol ?? [],
+    glim_fen: (raw.glim_fen ?? []).map((k: string) => FEN_FROM_BACKEND[k] ?? k),
+    glim_etiol: (raw.glim_etiol ?? []).map((k: string) => ETIOL_FROM_BACKEND[k] ?? k),
     inst: (raw.inst ?? []).map((i: any) => ({ // eslint-disable-line @typescript-eslint/no-explicit-any
       id: i.id ?? 0,
       t: i.t,
@@ -212,6 +212,97 @@ export const acknowledgeAlert = createAsyncThunk(
     } catch (err) {
       const axiosErr = err as AxiosError<{ error?: string; message?: string }>;
       const msg = axiosErr.response?.data?.error ?? axiosErr.response?.data?.message ?? axiosErr.message ?? "Error acknowledging alert";
+      return thunkAPI.rejectWithValue(msg);
+    }
+  }
+);
+
+const FEN_TO_BACKEND: Record<string, string> = {
+  perda_peso: "perda_peso",
+  baixo_imc: "imc_baixo",
+  massa_muscular: "reducao_mm",
+};
+
+const ETIOL_TO_BACKEND: Record<string, string> = {
+  reducao_ingestao: "ingestao_reduzida",
+  doenca_inflamacao: "inflamacao_aguda",
+};
+
+const FEN_FROM_BACKEND: Record<string, string> = {
+  perda_peso: "perda_peso",
+  imc_baixo: "baixo_imc",
+  reducao_mm: "massa_muscular",
+};
+
+const ETIOL_FROM_BACKEND: Record<string, string> = {
+  ingestao_reduzida: "reducao_ingestao",
+  inflamacao_aguda: "doenca_inflamacao",
+  inflamacao_cronica: "doenca_inflamacao",
+  inflamacao: "doenca_inflamacao",
+  ma_absorcao: "reducao_ingestao",
+};
+
+export const saveGlimToServer = createAsyncThunk(
+  "nutritional/saveGlimToServer",
+  async (
+    { id, glim_fen, glim_etiol, glim_diag, observacao }: {
+      id: number;
+      glim_fen: string[];
+      glim_etiol: string[];
+      glim_diag: GlimDiag;
+      observacao?: string;
+    },
+    thunkAPI
+  ) => {
+    try {
+      await instance.post(
+        `/nutritional/patients/${id}/glim`,
+        {
+          diagnostico: glim_diag,
+          fenotipos: glim_fen.map((k) => FEN_TO_BACKEND[k] ?? k),
+          etiologias: glim_etiol.map((k) => ETIOL_TO_BACKEND[k] ?? k),
+          observacao: observacao || undefined,
+        },
+        setHeaders(),
+      );
+      return { id, glim_fen, glim_etiol, glim_diag };
+    } catch (err) {
+      const axiosErr = err as AxiosError<{ error?: string; message?: string }>;
+      const msg = axiosErr.response?.data?.error ?? axiosErr.response?.data?.message ?? axiosErr.message ?? "Erro ao salvar GLIM";
+      return thunkAPI.rejectWithValue(msg);
+    }
+  }
+);
+
+export const saveAvalToServer = createAsyncThunk(
+  "nutritional/saveAvalToServer",
+  async (
+    { id, conduta, freq, ing, kcal, prot }: {
+      id: number;
+      conduta: string;
+      freq: string;
+      ing: number;
+      kcal?: number | null;
+      prot?: number | null;
+    },
+    thunkAPI
+  ) => {
+    try {
+      await instance.post(
+        `/nutritional/patients/${id}/assessments`,
+        {
+          conduta,
+          prox_visita: freq === "d7" ? "D7" : freq,
+          ingestao: ing,
+          meta_kcal: kcal ?? undefined,
+          meta_prot: prot ?? undefined,
+        },
+        setHeaders(),
+      );
+      return { id, conduta, freq, ing };
+    } catch (err) {
+      const axiosErr = err as AxiosError<{ error?: string; message?: string }>;
+      const msg = axiosErr.response?.data?.error ?? axiosErr.response?.data?.message ?? axiosErr.message ?? "Erro ao salvar avaliação";
       return thunkAPI.rejectWithValue(msg);
     }
   }
@@ -350,6 +441,29 @@ const nutritionalSlice = createSlice({
           patient.sev = campo1.classificacao ?? patient.sev;
           patient.mn_dims = campo1.mn_dims ?? patient.mn_dims;
           patient.nrs_completo = campo1.nrs_completo ?? patient.nrs_completo;
+        }
+      })
+      .addCase(saveGlimToServer.fulfilled, (state, action) => {
+        const { id, glim_fen, glim_etiol, glim_diag } = action.payload;
+        const patient = state.patients.find((p) => p.id === id);
+        if (patient) {
+          patient.glim_fen = glim_fen;
+          patient.glim_etiol = glim_etiol;
+          patient.glim_diag = glim_diag;
+        }
+      })
+      .addCase(saveAvalToServer.fulfilled, (state, action) => {
+        const { id, conduta, freq, ing } = action.payload;
+        const patient = state.patients.find((p) => p.id === id);
+        if (patient) {
+          patient.haval = 0;
+          patient.conduta = conduta;
+          const now = new Date();
+          const dd = String(now.getDate()).padStart(2, "0");
+          const mm = String(now.getMonth() + 1).padStart(2, "0");
+          const hh = String(now.getHours()).padStart(2, "0");
+          const min = String(now.getMinutes()).padStart(2, "0");
+          patient.hist.unshift({ h: `${dd}/${mm} ${hh}:${min}`, p: "Nutr. Silva", c: conduta, freq, ing });
         }
       });
   },

--- a/src/features/nutritional/components/PatientModal/PatientModal.tsx
+++ b/src/features/nutritional/components/PatientModal/PatientModal.tsx
@@ -24,15 +24,15 @@ import {
   NutritionalPatient,
   AcknowledgedEntry,
   GlimDiag,
-  saveGlim,
   saveNrsNut,
-  saveAval,
   confirmAllergy,
   acknowledgePatient,
   markAlertAcknowledged,
   revertAlert,
   fetchAlerts,
   acknowledgeAlert,
+  saveGlimToServer,
+  saveAvalToServer,
 } from "../../NutritionalSlice";
 import { MnutricManualForm } from "../MnutricManualForm/MnutricManualForm";
 import {
@@ -192,7 +192,7 @@ export function PatientModal({
   const handleSaveGlim = () => {
     if (!glimCanSave) return;
     dispatch(
-      saveGlim({
+      saveGlimToServer({
         id: p.id,
         glim_fen: fenSelected,
         glim_etiol: etiolSelected,
@@ -206,7 +206,7 @@ export function PatientModal({
   };
 
   const handleSaveAval = () => {
-    dispatch(saveAval({ id: p.id, conduta, freq, ing: ingestion }));
+    dispatch(saveAvalToServer({ id: p.id, conduta, freq, ing: ingestion }));
   };
 
   const handleConfirmAllergy = () => {

--- a/src/features/nutritional/components/PatientModal/PatientModal.tsx
+++ b/src/features/nutritional/components/PatientModal/PatientModal.tsx
@@ -29,11 +29,10 @@ import {
   saveAval,
   confirmAllergy,
   acknowledgePatient,
-  marcarAlertaReconhecido,
-  reverterAlerta,
-  fetchAlertas,
+  markAlertAcknowledged,
+  revertAlert,
+  fetchAlerts,
   acknowledgeAlert,
-  acknowledgeAllAlertas,
 } from "../../NutritionalSlice";
 import { MnutricManualForm } from "../MnutricManualForm/MnutricManualForm";
 import {
@@ -92,8 +91,8 @@ export function PatientModal({
   onTabChange,
 }: PatientModalProps) {
   const dispatch = useAppDispatch();
-  const alertasLoading = useAppSelector(
-    (state: any) => (state.nutritional.alertasLoading as Record<number, boolean>)[p?.id ?? -1] ?? false // eslint-disable-line @typescript-eslint/no-explicit-any
+  const alertsLoading = useAppSelector(
+    (state: any) => (state.nutritional.alertsLoading as Record<number, boolean>)[p?.id ?? -1] ?? false // eslint-disable-line @typescript-eslint/no-explicit-any
   );
 
   // ── NRS tab local state ───────────────────────────────────────────────
@@ -135,7 +134,7 @@ export function PatientModal({
 
   useEffect(() => {
     if (p && activeTab === "inst") {
-      dispatch(fetchAlertas(p.id));
+      dispatch(fetchAlerts(p.id));
     }
   }, [activeTab, p?.id]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -227,25 +226,27 @@ export function PatientModal({
     );
   };
 
-  const handleReconhecerAlerta = async (alertaId: number) => {
-    dispatch(marcarAlertaReconhecido({ patientId: p.id, alertaId }));
+  const handleAcknowledgeAlert = async (alertId: number) => {
+    dispatch(markAlertAcknowledged({ patientId: p.id, alertId }));
     try {
-      await dispatch(acknowledgeAlert({ patientId: p.id, alertaId })).unwrap();
+      await dispatch(acknowledgeAlert({ patientId: p.id, alertId })).unwrap();
     } catch {
-      dispatch(reverterAlerta({ patientId: p.id, alertaId }));
+      dispatch(revertAlert({ patientId: p.id, alertId }));
       message.error("Erro ao reconhecer alerta.");
     }
   };
 
-  const handleReconhecerTodos = async () => {
-    const alertasAtivos = p.inst.filter((i) => !i.ack);
-    const ids = alertasAtivos.map((i) => i.id);
-    ids.forEach((id) => dispatch(marcarAlertaReconhecido({ patientId: p.id, alertaId: id })));
-    try {
-      await dispatch(acknowledgeAllAlertas({ patientId: p.id, alertaIds: ids })).unwrap();
-    } catch {
-      ids.forEach((id) => dispatch(reverterAlerta({ patientId: p.id, alertaId: id })));
-      message.error("Erro ao reconhecer alertas.");
+  const handleAcknowledgeAll = async () => {
+    const activeAlerts = p.inst.filter((i) => !i.ack);
+    for (const alert of activeAlerts) {
+      dispatch(markAlertAcknowledged({ patientId: p.id, alertId: alert.id }));
+      try {
+        await dispatch(acknowledgeAlert({ patientId: p.id, alertId: alert.id })).unwrap(); // eslint-disable-line no-await-in-loop
+      } catch {
+        dispatch(revertAlert({ patientId: p.id, alertId: alert.id }));
+        message.error("Erro ao reconhecer alertas.");
+        break;
+      }
     }
   };
 
@@ -791,9 +792,9 @@ export function PatientModal({
 
   // ── Tab: Instabilidade ────────────────────────────────────────────────
 
-  const alertasAtivos = p.inst.filter((i) => !i.ack);
-  const labAtivos = alertasAtivos.filter((i) => i.t === "lab");
-  const clinRxAtivos = alertasAtivos.filter((i) => i.t !== "lab");
+  const activeAlerts = p.inst.filter((i) => !i.ack);
+  const activeLab = activeAlerts.filter((i) => i.t === "lab");
+  const activeClinRx = activeAlerts.filter((i) => i.t !== "lab");
 
   const tabInst = (
     <div>
@@ -828,11 +829,11 @@ export function PatientModal({
         />
       )}
 
-      {labAtivos.length > 0 && (
+      {activeLab.length > 0 && (
         <>
           <SectionTitle>Exames laboratoriais</SectionTitle>
           <InstPanel style={{ marginBottom: 16 }}>
-            {labAtivos.map((item) => (
+            {activeLab.map((item) => (
               <InstItemRow key={item.id}>
                 <InstDot $color={INST_DOT_COLOR.lab} />
                 <span style={{ flex: 1 }}>{item.d}</span>
@@ -841,8 +842,8 @@ export function PatientModal({
                   size="small"
                   type="text"
                   style={{ marginLeft: 8, fontSize: 11, color: "#3a9c6e" }}
-                  loading={alertasLoading}
-                  onClick={() => handleReconhecerAlerta(item.id)}
+                  loading={alertsLoading}
+                  onClick={() => handleAcknowledgeAlert(item.id)}
                 >
                   Reconhecer
                 </Button>
@@ -852,11 +853,11 @@ export function PatientModal({
         </>
       )}
 
-      {clinRxAtivos.length > 0 && (
+      {activeClinRx.length > 0 && (
         <>
           <SectionTitle>Achados clínicos / prescrição</SectionTitle>
           <InstPanel style={{ marginBottom: 16 }}>
-            {clinRxAtivos.map((item) => (
+            {activeClinRx.map((item) => (
               <InstItemRow key={item.id}>
                 <InstDot $color={INST_DOT_COLOR[item.t] ?? "#8c8c8c"} />
                 <span style={{ flex: 1 }}>{item.d}</span>
@@ -865,8 +866,8 @@ export function PatientModal({
                   size="small"
                   type="text"
                   style={{ marginLeft: 8, fontSize: 11, color: "#3a9c6e" }}
-                  loading={alertasLoading}
-                  onClick={() => handleReconhecerAlerta(item.id)}
+                  loading={alertsLoading}
+                  onClick={() => handleAcknowledgeAlert(item.id)}
                 >
                   Reconhecer
                 </Button>
@@ -876,7 +877,7 @@ export function PatientModal({
         </>
       )}
 
-      {alertasAtivos.length === 0 && (
+      {activeAlerts.length === 0 && (
         <Alert
           type="success"
           showIcon
@@ -886,13 +887,13 @@ export function PatientModal({
         />
       )}
 
-      {alertasAtivos.length > 0 && (
+      {activeAlerts.length > 0 && (
         <Button
           block
           type="primary"
-          loading={alertasLoading}
+          loading={alertsLoading}
           style={{ marginBottom: 16 }}
-          onClick={handleReconhecerTodos}
+          onClick={handleAcknowledgeAll}
         >
           ✓ Reconhecer todos os alertas ativos
         </Button>

--- a/src/features/nutritional/components/PatientModal/PatientModal.tsx
+++ b/src/features/nutritional/components/PatientModal/PatientModal.tsx
@@ -14,9 +14,10 @@ import {
   Radio,
   Button,
   Tooltip,
+  message,
 } from "antd";
 import { WarningOutlined, CheckCircleOutlined, ClockCircleOutlined } from "@ant-design/icons";
-import { useAppDispatch } from "src/store";
+import { useAppDispatch, useAppSelector } from "src/store";
 import { FeatureService } from "src/services/FeatureService";
 import Feature from "src/models/Feature";
 import {
@@ -28,6 +29,11 @@ import {
   saveAval,
   confirmAllergy,
   acknowledgePatient,
+  marcarAlertaReconhecido,
+  reverterAlerta,
+  fetchAlertas,
+  acknowledgeAlert,
+  acknowledgeAllAlertas,
 } from "../../NutritionalSlice";
 import { MnutricManualForm } from "../MnutricManualForm/MnutricManualForm";
 import {
@@ -86,6 +92,9 @@ export function PatientModal({
   onTabChange,
 }: PatientModalProps) {
   const dispatch = useAppDispatch();
+  const alertasLoading = useAppSelector(
+    (state: any) => (state.nutritional.alertasLoading as Record<number, boolean>)[p?.id ?? -1] ?? false // eslint-disable-line @typescript-eslint/no-explicit-any
+  );
 
   // ── NRS tab local state ───────────────────────────────────────────────
   const [nrsA, setNrsA] = useState(0);
@@ -123,6 +132,12 @@ export function PatientModal({
     setInstObs("");
     setAntecipar("");
   }, [p?.id]);
+
+  useEffect(() => {
+    if (p && activeTab === "inst") {
+      dispatch(fetchAlertas(p.id));
+    }
+  }, [activeTab, p?.id]); // eslint-disable-line react-hooks/exhaustive-deps
 
   if (!p) return null;
 
@@ -210,6 +225,28 @@ export function PatientModal({
         prof: "Nutr. Silva",
       })
     );
+  };
+
+  const handleReconhecerAlerta = async (alertaId: number) => {
+    dispatch(marcarAlertaReconhecido({ patientId: p.id, alertaId }));
+    try {
+      await dispatch(acknowledgeAlert({ patientId: p.id, alertaId })).unwrap();
+    } catch {
+      dispatch(reverterAlerta({ patientId: p.id, alertaId }));
+      message.error("Erro ao reconhecer alerta.");
+    }
+  };
+
+  const handleReconhecerTodos = async () => {
+    const alertasAtivos = p.inst.filter((i) => !i.ack);
+    const ids = alertasAtivos.map((i) => i.id);
+    ids.forEach((id) => dispatch(marcarAlertaReconhecido({ patientId: p.id, alertaId: id })));
+    try {
+      await dispatch(acknowledgeAllAlertas({ patientId: p.id, alertaIds: ids })).unwrap();
+    } catch {
+      ids.forEach((id) => dispatch(reverterAlerta({ patientId: p.id, alertaId: id })));
+      message.error("Erro ao reconhecer alertas.");
+    }
   };
 
   // ── Tab: Resumo ───────────────────────────────────────────────────────
@@ -754,6 +791,10 @@ export function PatientModal({
 
   // ── Tab: Instabilidade ────────────────────────────────────────────────
 
+  const alertasAtivos = p.inst.filter((i) => !i.ack);
+  const labAtivos = alertasAtivos.filter((i) => i.t === "lab");
+  const clinRxAtivos = alertasAtivos.filter((i) => i.t !== "lab");
+
   const tabInst = (
     <div>
       {p.alergia && !p.alOk && (
@@ -787,38 +828,74 @@ export function PatientModal({
         />
       )}
 
-      {p.inst.filter((i) => i.t === "lab").length > 0 && (
+      {labAtivos.length > 0 && (
         <>
           <SectionTitle>Exames laboratoriais</SectionTitle>
           <InstPanel style={{ marginBottom: 16 }}>
-            {p.inst
-              .filter((i) => i.t === "lab")
-              .map((item, i) => (
-                <InstItemRow key={i}>
-                  <InstDot $color={INST_DOT_COLOR.lab} />
-                  <span>{item.d}</span>
-                  <InstTypeLabel>Laboratório</InstTypeLabel>
-                </InstItemRow>
-              ))}
+            {labAtivos.map((item) => (
+              <InstItemRow key={item.id}>
+                <InstDot $color={INST_DOT_COLOR.lab} />
+                <span style={{ flex: 1 }}>{item.d}</span>
+                <InstTypeLabel>Laboratório</InstTypeLabel>
+                <Button
+                  size="small"
+                  type="text"
+                  style={{ marginLeft: 8, fontSize: 11, color: "#3a9c6e" }}
+                  loading={alertasLoading}
+                  onClick={() => handleReconhecerAlerta(item.id)}
+                >
+                  Reconhecer
+                </Button>
+              </InstItemRow>
+            ))}
           </InstPanel>
         </>
       )}
 
-      {p.inst.filter((i) => i.t !== "lab").length > 0 && (
+      {clinRxAtivos.length > 0 && (
         <>
           <SectionTitle>Achados clínicos / prescrição</SectionTitle>
           <InstPanel style={{ marginBottom: 16 }}>
-            {p.inst
-              .filter((i) => i.t !== "lab")
-              .map((item, i) => (
-                <InstItemRow key={i}>
-                  <InstDot $color={INST_DOT_COLOR[item.t] ?? "#8c8c8c"} />
-                  <span>{item.d}</span>
-                  <InstTypeLabel>{INST_TYPE_LABEL[item.t] ?? item.t}</InstTypeLabel>
-                </InstItemRow>
-              ))}
+            {clinRxAtivos.map((item) => (
+              <InstItemRow key={item.id}>
+                <InstDot $color={INST_DOT_COLOR[item.t] ?? "#8c8c8c"} />
+                <span style={{ flex: 1 }}>{item.d}</span>
+                <InstTypeLabel>{INST_TYPE_LABEL[item.t] ?? item.t}</InstTypeLabel>
+                <Button
+                  size="small"
+                  type="text"
+                  style={{ marginLeft: 8, fontSize: 11, color: "#3a9c6e" }}
+                  loading={alertasLoading}
+                  onClick={() => handleReconhecerAlerta(item.id)}
+                >
+                  Reconhecer
+                </Button>
+              </InstItemRow>
+            ))}
           </InstPanel>
         </>
+      )}
+
+      {alertasAtivos.length === 0 && (
+        <Alert
+          type="success"
+          showIcon
+          icon={<CheckCircleOutlined />}
+          message="Todos os alertas reconhecidos"
+          style={{ marginBottom: 16 }}
+        />
+      )}
+
+      {alertasAtivos.length > 0 && (
+        <Button
+          block
+          type="primary"
+          loading={alertasLoading}
+          style={{ marginBottom: 16 }}
+          onClick={handleReconhecerTodos}
+        >
+          ✓ Reconhecer todos os alertas ativos
+        </Button>
       )}
 
       <div style={{ marginBottom: 16 }}>
@@ -839,7 +916,10 @@ export function PatientModal({
         </div>
         <Radio.Group
           value={antecipar}
-          onChange={(e) => setAntecipar(e.target.value)}
+          onChange={(e) => {
+            setAntecipar(e.target.value);
+            if (e.target.value === "sim") onTabChange("aval");
+          }}
         >
           <Radio value="sim">Sim – antecipar</Radio>
           <Radio value="nao">Não – manter programação</Radio>

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -959,21 +959,14 @@ api.nutritional.saveNrsNut = (nratendimento, data) =>
     ...setHeaders(),
   });
 
-api.nutritional.getAlertas = (nratendimento) =>
-  instance.get(`/nutritional/patients/${nratendimento}/alertas`, {
+api.nutritional.getAlerts = (nratendimento) =>
+  instance.get(`/nutritional/patients/${nratendimento}/alerts`, {
     ...setHeaders(),
   });
 
-api.nutritional.acknowledgeAlert = (nratendimento, alertaId) =>
+api.nutritional.acknowledgeAlert = (nratendimento, alertId) =>
   instance.post(
-    `/nutritional/patients/${nratendimento}/alertas/${alertaId}/acknowledge`,
-    {},
-    { ...setHeaders() },
-  );
-
-api.nutritional.acknowledgeAllAlertas = (nratendimento) =>
-  instance.post(
-    `/nutritional/patients/${nratendimento}/alertas/acknowledge-all`,
+    `/nutritional/patients/${nratendimento}/alerts/${alertId}/acknowledge`,
     {},
     { ...setHeaders() },
   );

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -959,6 +959,25 @@ api.nutritional.saveNrsNut = (nratendimento, data) =>
     ...setHeaders(),
   });
 
+api.nutritional.getAlertas = (nratendimento) =>
+  instance.get(`/nutritional/patients/${nratendimento}/alertas`, {
+    ...setHeaders(),
+  });
+
+api.nutritional.acknowledgeAlert = (nratendimento, alertaId) =>
+  instance.post(
+    `/nutritional/patients/${nratendimento}/alertas/${alertaId}/acknowledge`,
+    {},
+    { ...setHeaders() },
+  );
+
+api.nutritional.acknowledgeAllAlertas = (nratendimento) =>
+  instance.post(
+    `/nutritional/patients/${nratendimento}/alertas/acknowledge-all`,
+    {},
+    { ...setHeaders() },
+  );
+
 /** GENERAL */
 api.general = {};
 const getVersion = () =>

--- a/src/services/nutritional/api.ts
+++ b/src/services/nutritional/api.ts
@@ -18,6 +18,7 @@ type API = typeof apiModule & {
 
 
 const api = apiModule as API;
+api.nutritional = {} as NutritionalAPI;
 
 
 /**
@@ -57,7 +58,7 @@ api.nutritional.saveNrsNut = (nratendimento: number, data: NrsNutPayload) =>
  * @returns Promise with saved GLIM diagnosis
  */
 api.nutritional.saveGlim = (nratendimento: number, data: GlimPayload) =>
-  instance.put(
+  instance.post(
     `/nutritional/patients/${nratendimento}/glim`,
     data,
     setHeaders(),
@@ -108,7 +109,7 @@ export interface GlimPayload {
 
 export interface AvalPayload {
   conduta: string;
-  frequencia: '12h' | '24h' | '48h' | '7d' | 'rotina';
+  prox_visita: '12h' | '24h' | '48h' | '7d' | 'rotina';
   ingestao?: number;
   meta_kcal?: number;
   meta_prot?: number;

--- a/src/services/nutritional/api.ts
+++ b/src/services/nutritional/api.ts
@@ -28,7 +28,7 @@ const api = apiModule as API;
  * @returns Promise with the list of patients and their nutritional scores
  */
 api.nutritional.getPatients = (params?: { setor?: number; ala?: string }) =>
-  instance.get('/patients', {
+  instance.get('/nutritional/patients', {
     params,
     ...setHeaders(),
   });
@@ -44,7 +44,7 @@ api.nutritional.getPatients = (params?: { setor?: number; ala?: string }) =>
  */
 api.nutritional.saveNrsNut = (nratendimento: number, data: NrsNutPayload) =>
   instance.put(
-    `/patients/${nratendimento}/nrs-nut`,
+    `/nutritional/patients/${nratendimento}/nrs-nut`,
     data,
     setHeaders(),
   );
@@ -58,7 +58,7 @@ api.nutritional.saveNrsNut = (nratendimento: number, data: NrsNutPayload) =>
  */
 api.nutritional.saveGlim = (nratendimento: number, data: GlimPayload) =>
   instance.put(
-    `/patients/${nratendimento}/glim`,
+    `/nutritional/patients/${nratendimento}/glim`,
     data,
     setHeaders(),
   );
@@ -73,7 +73,7 @@ api.nutritional.saveGlim = (nratendimento: number, data: GlimPayload) =>
  */
 api.nutritional.saveAval = (nratendimento: number, data: AvalPayload) =>
   instance.post(
-    `/patients/${nratendimento}/assessments`,
+    `/nutritional/patients/${nratendimento}/assessments`,
     data,
     setHeaders(),
   );
@@ -87,7 +87,7 @@ api.nutritional.saveAval = (nratendimento: number, data: AvalPayload) =>
  */
 api.nutritional.acknowledgePatient = (nratendimento: number) =>
   instance.post(
-    `/patients/${nratendimento}/acknowledge`,
+    `/nutritional/patients/${nratendimento}/acknowledge`,
     {},
     setHeaders(),
   );
@@ -116,11 +116,11 @@ export interface AvalPayload {
 
 
 api.nutritional.getAlerts = (nratendimento: number) =>
-  instance.get(`/patients/${nratendimento}/alerts`, setHeaders());
+  instance.get(`/nutritional/patients/${nratendimento}/alerts`, setHeaders());
 
 api.nutritional.acknowledgeAlert = (nratendimento: number, alertId: number) =>
   instance.post(
-    `/patients/${nratendimento}/alerts/${alertId}/acknowledge`,
+    `/nutritional/patients/${nratendimento}/alerts/${alertId}/acknowledge`,
     {},
     setHeaders(),
   );

--- a/src/services/nutritional/api.ts
+++ b/src/services/nutritional/api.ts
@@ -7,6 +7,9 @@ interface NutritionalAPI {
   saveGlim: (nratendimento: number, data: GlimPayload) => any;
   saveAval: (nratendimento: number, data: AvalPayload) => any;
   acknowledgePatient: (nratendimento: number) => any;
+  getAlertas: (nratendimento: number) => any;
+  acknowledgeAlert: (nratendimento: number, alertaId: number) => any;
+  acknowledgeAllAlertas: (nratendimento: number) => any;
 };
 
 
@@ -111,6 +114,24 @@ export interface AvalPayload {
   meta_kcal?: number;
   meta_prot?: number;
 };
+
+
+api.nutritional.getAlertas = (nratendimento: number) =>
+  instance.get(`/patients/${nratendimento}/alertas`, setHeaders());
+
+api.nutritional.acknowledgeAlert = (nratendimento: number, alertaId: number) =>
+  instance.post(
+    `/patients/${nratendimento}/alertas/${alertaId}/acknowledge`,
+    {},
+    setHeaders(),
+  );
+
+api.nutritional.acknowledgeAllAlertas = (nratendimento: number) =>
+  instance.post(
+    `/patients/${nratendimento}/alertas/acknowledge-all`,
+    {},
+    setHeaders(),
+  );
 
 
 export default api;

--- a/src/services/nutritional/api.ts
+++ b/src/services/nutritional/api.ts
@@ -7,9 +7,8 @@ interface NutritionalAPI {
   saveGlim: (nratendimento: number, data: GlimPayload) => any;
   saveAval: (nratendimento: number, data: AvalPayload) => any;
   acknowledgePatient: (nratendimento: number) => any;
-  getAlertas: (nratendimento: number) => any;
-  acknowledgeAlert: (nratendimento: number, alertaId: number) => any;
-  acknowledgeAllAlertas: (nratendimento: number) => any;
+  getAlerts: (nratendimento: number) => any;
+  acknowledgeAlert: (nratendimento: number, alertId: number) => any;
 };
 
 
@@ -74,7 +73,7 @@ api.nutritional.saveGlim = (nratendimento: number, data: GlimPayload) =>
  */
 api.nutritional.saveAval = (nratendimento: number, data: AvalPayload) =>
   instance.post(
-    `/patients/${nratendimento}/assessment`,
+    `/patients/${nratendimento}/assessments`,
     data,
     setHeaders(),
   );
@@ -116,19 +115,12 @@ export interface AvalPayload {
 };
 
 
-api.nutritional.getAlertas = (nratendimento: number) =>
-  instance.get(`/patients/${nratendimento}/alertas`, setHeaders());
+api.nutritional.getAlerts = (nratendimento: number) =>
+  instance.get(`/patients/${nratendimento}/alerts`, setHeaders());
 
-api.nutritional.acknowledgeAlert = (nratendimento: number, alertaId: number) =>
+api.nutritional.acknowledgeAlert = (nratendimento: number, alertId: number) =>
   instance.post(
-    `/patients/${nratendimento}/alertas/${alertaId}/acknowledge`,
-    {},
-    setHeaders(),
-  );
-
-api.nutritional.acknowledgeAllAlertas = (nratendimento: number) =>
-  instance.post(
-    `/patients/${nratendimento}/alertas/acknowledge-all`,
+    `/patients/${nratendimento}/alerts/${alertId}/acknowledge`,
     {},
     setHeaders(),
   );

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
     port: 3000,
      proxy: {
       "/api": {
-        target: "http://localhost:5000/",
+        target: "https://nf5vrtmgfieecoc3kewsih2yem0wclkd.lambda-url.us-east-2.on.aws",
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api/, ""),
       },


### PR DESCRIPTION
feat(us-fe-11): Tab Instabilidade com reconhecimento de alertas
  
  O que foi implementado

  - Tab Instabilidade no modal de paciente exibe apenas alertas ativos (não reconhecidos)
  - Botão "Reconhecer" individual por alerta
  - Botão "Reconhecer todos os alertas ativos" em bulk
  - Optimistic update: marca localmente → chama API → reverte se falhar
  - Alertas carregados da API ao abrir a aba
  - Redirecionamento automático para aba Avaliação ao selecionar "Antecipar → Sim"
  - Mensagem de sucesso quando todos os alertas estão reconhecidos

  Endpoints utilizados

  - GET /nutritional/patients/{nratendimento}/alerts
  - POST /nutritional/patients/{nratendimento}/alerts/{alertId}/acknowledge

  Correções

  - Prefixo /nutritional adicionado a todos os endpoints da API nutricional
  - saveAval: /patients/{id}/assessment → /patients/{id}/assessments