### PR TITLE
fix(us-fe-23): corrigir endpoint mnutric-manual

### DIFF
--- a/src/services/api.js
+++ b/src/services/api.js
@@ -955,7 +955,7 @@ api.nutritional.getPatients = (params = {}) =>
   });
 
 api.nutritional.saveNrsNut = (nratendimento, data) =>
-  instance.put(`/nutritional/patients/${nratendimento}/nrs-nut`, data, {
+  instance.put(`/nutritional/patients/${nratendimento}/mnutric-manual`, data, {
     ...setHeaders(),
   });
 


### PR DESCRIPTION
## Summary

- Corrige mismatch de contrato no endpoint de cálculo manual de mNUTRIC
- `PUT /nutritional/patients/:id/nrs-nut` → `PUT /nutritional/patients/:id/mnutric-manual`
- Arquivo: `src/services/api.js`

Closes #73

## Test plan

- [x] Preencher APACHE II e SOFA no formulário manual de mNUTRIC (paciente UTI com `dados_incompletos`)
- [x] Clicar "Calcular mNUTRIC" — request deve ir para `/nutritional/patients/:id/mnutric-manual`
- [x] Sucesso: score mNUTRIC atualizado na UI sem reload
- [x] Erro de backend: mensagem inline no formulário

🤖 Generated with [Claude Code](https://claude.com/claude-code)