### PR TITLE
feat(US-FE-16): chips de instabilidade por severidade no card e modal

### DIFF
--- a/src/features/nutritional/NutritionalSlice.ts
+++ b/src/features/nutritional/NutritionalSlice.ts
@@ -6,9 +6,18 @@ export type AlaType = "UTI" | "B" | "C";
 export type SeverityType = "cr" | "al" | "md" | "bx";
 export type GlimDiag = "nd" | "mod" | "grave" | null;
 
+// Mapeamento de severidade do backend (nomes por extenso) → abreviações do frontend
+const SEV_MAP_FROM_BACKEND: Record<string, string> = {
+  vermelho: "cr",
+  laranja: "al",
+  amarelo: "md",
+  verde: "bx",
+};
+
 export interface InstItem {
   id: number;
   t: "lab" | "clin" | "rx";
+  sev: "cr" | "al" | "md";
   d: string;
   ack: boolean;
 }
@@ -96,10 +105,21 @@ function normalizeAla(raw: string | null | undefined): AlaType {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function normalizeApiPatient(raw: any): NutritionalPatient {
+export function normalizeApiAlert(i: any): InstItem {
+  return {
+    id: i.id ?? 0,
+    t: i.t ?? i.tipo ?? "lab",
+    sev: i.sev ?? SEV_MAP_FROM_BACKEND[i.severidade] ?? "md",
+    d: i.d ?? i.descricao ?? "",
+    ack: i.ack ?? i.reconhecido ?? false,
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function normalizeApiPatient(raw: any): NutritionalPatient {
   const c1 = raw.campo1 ?? {};
   return {
-    id: raw.id,
+    id: raw.id ?? 0,
     leito: raw.leito ?? "—",
     ala: normalizeAla(raw.nome_setor ?? raw.ala),
     nome: raw.nome ?? "",
@@ -125,12 +145,7 @@ function normalizeApiPatient(raw: any): NutritionalPatient {
     glim_diag: raw.glim_diag ?? null,
     glim_fen: (raw.glim_fen ?? []).map((k: string) => FEN_FROM_BACKEND[k] ?? k),
     glim_etiol: (raw.glim_etiol ?? []).map((k: string) => ETIOL_FROM_BACKEND[k] ?? k),
-    inst: (raw.inst ?? []).map((i: any) => ({ // eslint-disable-line @typescript-eslint/no-explicit-any
-      id: i.id ?? 0,
-      t: i.t,
-      d: i.d,
-      ack: i.ack ?? false,
-    })),
+    inst: (raw.inst ?? []).map(normalizeApiAlert),
     conduta: raw.conduta ?? "",
     alergia: raw.alergia ?? null,
     alOk: raw.al_ok ?? raw.alOk ?? true,
@@ -193,7 +208,13 @@ export const fetchAlerts = createAsyncThunk(
       const raw: any[] = Array.isArray(response.data) ? response.data : response.data?.data ?? []; // eslint-disable-line @typescript-eslint/no-explicit-any
       return {
         patientId,
-        alerts: raw.map((i: any) => ({ id: i.id ?? 0, t: i.t, d: i.d, ack: i.ack ?? false })), // eslint-disable-line @typescript-eslint/no-explicit-any
+        alerts: raw.map((i: any) => ({ // eslint-disable-line @typescript-eslint/no-explicit-any
+          id: i.id ?? 0,
+          t: i.t ?? i.tipo ?? "lab",
+          sev: i.sev ?? SEV_MAP_FROM_BACKEND[i.severidade] ?? "md",
+          d: i.d ?? i.descricao ?? "",
+          ack: i.ack ?? i.reconhecido ?? false,
+        })),
       };
     } catch (err) {
       const axiosErr = err as AxiosError<{ error?: string; message?: string }>;
@@ -211,6 +232,10 @@ export const acknowledgeAlert = createAsyncThunk(
       return { patientId, alertId };
     } catch (err) {
       const axiosErr = err as AxiosError<{ error?: string; message?: string }>;
+      // 409 = já reconhecido — tratar como sucesso (idempotência)
+      if (axiosErr.response?.status === 409) {
+        return { patientId, alertId };
+      }
       const msg = axiosErr.response?.data?.error ?? axiosErr.response?.data?.message ?? axiosErr.message ?? "Error acknowledging alert";
       return thunkAPI.rejectWithValue(msg);
     }
@@ -427,7 +452,7 @@ const nutritionalSlice = createSlice({
         const { patientId, alerts } = action.payload;
         state.alertsLoading[patientId] = false;
         const patient = state.patients.find((p) => p.id === patientId);
-        if (patient) patient.inst = alerts;
+        if (patient) patient.inst = alerts.map(normalizeApiAlert);
       })
       .addCase(fetchAlerts.rejected, (state, action) => {
         state.alertsLoading[action.meta.arg] = false;

--- a/src/features/nutritional/components/PatientCard/PatientCard.tsx
+++ b/src/features/nutritional/components/PatientCard/PatientCard.tsx
@@ -24,9 +24,9 @@ interface PatientCardProps {
 }
 
 const INST_STYLE: Record<string, { bg: string; color: string; border: string }> = {
-  lab: { bg: "#fcebeb", color: "#a32d2d", border: "#f09595" },
-  clin: { bg: "#fdf3dc", color: "#b7770d", border: "#fac775" },
-  rx: { bg: "#f0eeff", color: "#3c3489", border: "#b39ddb" },
+  cr: { bg: "#fcebeb", color: "#a32d2d", border: "#f09595" },
+  al: { bg: "#fdf3dc", color: "#b7770d", border: "#fac775" },
+  md: { bg: "#f0eeff", color: "#3c3489", border: "#b39ddb" },
 };
 
 export function PatientCard({
@@ -54,11 +54,22 @@ export function PatientCard({
           ? "#3a9c6e"
           : "#d4931a";
 
-  const instSlice = p.inst.slice(0, 3);
-  const instMore = p.inst.length > 3 ? p.inst.length - 3 : 0;
+  // Determine highest severity from active (non-ack) alerts for card border
+  const SEV_PRIORITY: Record<string, number> = { cr: 3, al: 2, md: 1 };
+  const activeInst = p.inst.filter((i) => !i.ack);
+  const highestInstSev = activeInst.length > 0
+    ? activeInst.reduce((max, item) => {
+        const cur = SEV_PRIORITY[item.sev] ?? 0;
+        const prev = SEV_PRIORITY[max] ?? 0;
+        return cur > prev ? item.sev : max;
+      }, activeInst[0].sev)
+    : null;
+
+  const instSlice = activeInst.slice(0, 3);
+  const instMore = activeInst.length > 3 ? activeInst.length - 3 : 0;
 
   return (
-    <Card $sev={p.sev} $atend={isAtend}>
+    <Card $sev={highestInstSev ?? p.sev} $atend={isAtend}>
       <CardBody onClick={onClick}>
         <CardTop>
           <BedLabel>{p.leito}</BedLabel>
@@ -160,12 +171,12 @@ export function PatientCard({
         </GlimText>
 
         {/* Campo 3 – Instabilidade */}
-        {p.inst.length > 0 && (
+        {activeInst.length > 0 && (
           <>
             <SectionLabel>Campo 3 – Instabilidade</SectionLabel>
             <TagsRow>
               {instSlice.map((item, i) => {
-                const st = INST_STYLE[item.t] ?? INST_STYLE.lab;
+                const st = INST_STYLE[item.sev] ?? INST_STYLE.md;
                 return (
                   <Tooltip key={i} title={item.d}>
                     <Badge $bg={st.bg} $color={st.color} $border={st.border}>

--- a/src/features/nutritional/components/PatientCard/PatientCard.tsx
+++ b/src/features/nutritional/components/PatientCard/PatientCard.tsx
@@ -11,6 +11,7 @@ import {
   sevMNUTRIC,
   sevNRS,
   GLIM_LABEL,
+  INST_STYLE,
 } from "../../nutritionalUtils";
 import { CardBody, CardTop, BedLabel, BadgeRow, PatientName, PatientMeta, SectionLabel, ScoreDual, ScoreChip, ScoreSingle, GlimText, TagsRow, CardFooter, ActionBtn, Badge, Card } from "./styles";
 import { Tooltip } from "antd";
@@ -22,12 +23,6 @@ interface PatientCardProps {
   onClick: () => void;
   onOpenTab: (tab: string) => void;
 }
-
-const INST_STYLE: Record<string, { bg: string; color: string; border: string }> = {
-  cr: { bg: "#fcebeb", color: "#a32d2d", border: "#f09595" },
-  al: { bg: "#fdf3dc", color: "#b7770d", border: "#fac775" },
-  md: { bg: "#f0eeff", color: "#3c3489", border: "#b39ddb" },
-};
 
 export function PatientCard({
   patient: p,

--- a/src/features/nutritional/components/PatientModal/PatientModal.tsx
+++ b/src/features/nutritional/components/PatientModal/PatientModal.tsx
@@ -228,17 +228,12 @@ export function PatientModal({
   };
 
   const handleAcknowledgeAlert = async (alertId: number) => {
-    if (ackInProgress.current) {
-      console.warn("handleAcknowledgeAlert blocked — already in progress");
-      return;
-    }
+    if (ackInProgress.current) return;
     ackInProgress.current = true;
-    console.trace(">>> handleAcknowledgeAlert CALLED, alertId:", alertId);
     try {
       dispatch(markAlertAcknowledged({ patientId: p.id, alertId }));
       const action = await dispatch(acknowledgeAlert({ patientId: p.id, alertId }));
       if (acknowledgeAlert.rejected.match(action)) {
-        console.error("AcknowledgeAlert Error:", action.payload);
         dispatch(revertAlert({ patientId: p.id, alertId }));
         message.error("Erro ao reconhecer: " + String(action.payload));
       }
@@ -248,19 +243,14 @@ export function PatientModal({
   };
 
   const handleAcknowledgeAll = async () => {
-    if (ackInProgress.current) {
-      console.warn("handleAcknowledgeAll blocked — already in progress");
-      return;
-    }
+    if (ackInProgress.current) return;
     ackInProgress.current = true;
-    console.trace(">>> handleAcknowledgeAll CALLED");
     try {
       const activeAlerts = p.inst.filter((i) => !i.ack);
       for (const alert of activeAlerts) {
         dispatch(markAlertAcknowledged({ patientId: p.id, alertId: alert.id }));
         const action = await dispatch(acknowledgeAlert({ patientId: p.id, alertId: alert.id })); // eslint-disable-line no-await-in-loop
         if (acknowledgeAlert.rejected.match(action)) {
-          console.error("AcknowledgeAll Error:", action.payload);
           dispatch(revertAlert({ patientId: p.id, alertId: alert.id }));
           message.error("Erro geral: " + String(action.payload));
           break;

--- a/src/features/nutritional/components/PatientModal/PatientModal.tsx
+++ b/src/features/nutritional/components/PatientModal/PatientModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   Modal,
   Row,
@@ -37,6 +37,7 @@ import {
 import { MnutricManualForm } from "../MnutricManualForm/MnutricManualForm";
 import {
   SEV_CONFIG,
+  INST_STYLE,
   ALA_CONFIG,
   calcMbcd,
   sevMNUTRIC,
@@ -45,13 +46,12 @@ import {
   GLIM_FEN_LABEL,
   GLIM_ETIOL_LABEL,
 } from "../../nutritionalUtils";
-import { InfoBlock, SectionTitle, ScorePanel, ScorePanelTitle, ScorePanelValue, DimsGrid, DimChip, GlimPanel, GlimSectionLabel, ChipsRow, Chip, GlimDiagBadge, GovernanceNote, InstPanel, InstItemRow, InstDot, InstTypeLabel, GlimResultBox, HistEntry } from "./styles";
+import { InfoBlock, SectionTitle, ScorePanel, ScorePanelTitle, ScorePanelValue, DimsGrid, DimChip, GlimPanel, GlimSectionLabel, ChipsRow, Chip, GlimDiagBadge, GovernanceNote, InstPanel, InstItemRow, InstTypeLabel, GlimResultBox, HistEntry, InstSevBadge } from "./styles";
 
-
-const INST_DOT_COLOR: Record<string, string> = {
-  lab: "#e24b4a",
-  clin: "#d4931a",
-  rx: "#7e57c2",
+const INST_SEV_LABEL: Record<string, string> = {
+  cr: "Crítico",
+  al: "Alto",
+  md: "Médio",
 };
 
 const INST_TYPE_LABEL: Record<string, string> = {
@@ -114,6 +114,7 @@ export function PatientModal({
   // ── Inst tab local state ──────────────────────────────────────────────
   const [instObs, setInstObs] = useState("");
   const [antecipar, setAntecipar] = useState<string>("");
+  const ackInProgress = useRef(false);
 
   // ── Initialize from patient ───────────────────────────────────────────
   useEffect(() => {
@@ -227,26 +228,46 @@ export function PatientModal({
   };
 
   const handleAcknowledgeAlert = async (alertId: number) => {
-    dispatch(markAlertAcknowledged({ patientId: p.id, alertId }));
+    if (ackInProgress.current) {
+      console.warn("handleAcknowledgeAlert blocked — already in progress");
+      return;
+    }
+    ackInProgress.current = true;
+    console.trace(">>> handleAcknowledgeAlert CALLED, alertId:", alertId);
     try {
-      await dispatch(acknowledgeAlert({ patientId: p.id, alertId })).unwrap();
-    } catch {
-      dispatch(revertAlert({ patientId: p.id, alertId }));
-      message.error("Erro ao reconhecer alerta.");
+      dispatch(markAlertAcknowledged({ patientId: p.id, alertId }));
+      const action = await dispatch(acknowledgeAlert({ patientId: p.id, alertId }));
+      if (acknowledgeAlert.rejected.match(action)) {
+        console.error("AcknowledgeAlert Error:", action.payload);
+        dispatch(revertAlert({ patientId: p.id, alertId }));
+        message.error("Erro ao reconhecer: " + String(action.payload));
+      }
+    } finally {
+      ackInProgress.current = false;
     }
   };
 
   const handleAcknowledgeAll = async () => {
-    const activeAlerts = p.inst.filter((i) => !i.ack);
-    for (const alert of activeAlerts) {
-      dispatch(markAlertAcknowledged({ patientId: p.id, alertId: alert.id }));
-      try {
-        await dispatch(acknowledgeAlert({ patientId: p.id, alertId: alert.id })).unwrap(); // eslint-disable-line no-await-in-loop
-      } catch {
-        dispatch(revertAlert({ patientId: p.id, alertId: alert.id }));
-        message.error("Erro ao reconhecer alertas.");
-        break;
+    if (ackInProgress.current) {
+      console.warn("handleAcknowledgeAll blocked — already in progress");
+      return;
+    }
+    ackInProgress.current = true;
+    console.trace(">>> handleAcknowledgeAll CALLED");
+    try {
+      const activeAlerts = p.inst.filter((i) => !i.ack);
+      for (const alert of activeAlerts) {
+        dispatch(markAlertAcknowledged({ patientId: p.id, alertId: alert.id }));
+        const action = await dispatch(acknowledgeAlert({ patientId: p.id, alertId: alert.id })); // eslint-disable-line no-await-in-loop
+        if (acknowledgeAlert.rejected.match(action)) {
+          console.error("AcknowledgeAll Error:", action.payload);
+          dispatch(revertAlert({ patientId: p.id, alertId: alert.id }));
+          message.error("Erro geral: " + String(action.payload));
+          break;
+        }
       }
+    } finally {
+      ackInProgress.current = false;
     }
   };
 
@@ -459,7 +480,7 @@ export function PatientModal({
           <InstPanel style={{ marginBottom: 12 }}>
             {p.inst.map((item, i) => (
               <InstItemRow key={i}>
-                <InstDot $color={INST_DOT_COLOR[item.t] ?? "#8c8c8c"} />
+                { (() => { const st = INST_STYLE[item.sev] ?? INST_STYLE.md; return <InstSevBadge $bg={st.bg} $color={st.color} $border={st.border}>{INST_SEV_LABEL[item.sev] ?? "Médio"}</InstSevBadge>; })() }
                 <span>{item.d}</span>
                 <InstTypeLabel>{INST_TYPE_LABEL[item.t] ?? item.t}</InstTypeLabel>
               </InstItemRow>
@@ -835,7 +856,7 @@ export function PatientModal({
           <InstPanel style={{ marginBottom: 16 }}>
             {activeLab.map((item) => (
               <InstItemRow key={item.id}>
-                <InstDot $color={INST_DOT_COLOR.lab} />
+                { (() => { const st = INST_STYLE[item.sev] ?? INST_STYLE.md; return <InstSevBadge $bg={st.bg} $color={st.color} $border={st.border}>{INST_SEV_LABEL[item.sev] ?? "Médio"}</InstSevBadge>; })() }
                 <span style={{ flex: 1 }}>{item.d}</span>
                 <InstTypeLabel>Laboratório</InstTypeLabel>
                 <Button
@@ -857,22 +878,27 @@ export function PatientModal({
         <>
           <SectionTitle>Achados clínicos / prescrição</SectionTitle>
           <InstPanel style={{ marginBottom: 16 }}>
-            {activeClinRx.map((item) => (
-              <InstItemRow key={item.id}>
-                <InstDot $color={INST_DOT_COLOR[item.t] ?? "#8c8c8c"} />
-                <span style={{ flex: 1 }}>{item.d}</span>
-                <InstTypeLabel>{INST_TYPE_LABEL[item.t] ?? item.t}</InstTypeLabel>
-                <Button
-                  size="small"
-                  type="text"
-                  style={{ marginLeft: 8, fontSize: 11, color: "#3a9c6e" }}
-                  loading={alertsLoading}
-                  onClick={() => handleAcknowledgeAlert(item.id)}
-                >
-                  Reconhecer
-                </Button>
-              </InstItemRow>
-            ))}
+            {activeClinRx.map((item) => {
+              const st = INST_STYLE[item.sev] ?? INST_STYLE.md;
+              return (
+                <InstItemRow key={item.id}>
+                  <InstSevBadge $bg={st.bg} $color={st.color} $border={st.border}>
+                    {INST_SEV_LABEL[item.sev] ?? "Médio"}
+                  </InstSevBadge>
+                  <span style={{ flex: 1, marginLeft: 8 }}>{item.d}</span>
+                  <InstTypeLabel>{INST_TYPE_LABEL[item.t] ?? item.t}</InstTypeLabel>
+                  <Button
+                    size="small"
+                    type="text"
+                    style={{ marginLeft: 8, fontSize: 11, color: "#3a9c6e" }}
+                    loading={alertsLoading}
+                    onClick={() => handleAcknowledgeAlert(item.id)}
+                  >
+                    Reconhecer
+                  </Button>
+                </InstItemRow>
+              );
+            })}
           </InstPanel>
         </>
       )}

--- a/src/features/nutritional/components/PatientModal/styles.tsx
+++ b/src/features/nutritional/components/PatientModal/styles.tsx
@@ -255,3 +255,18 @@ export const GlimResultBox = styled.div<{ $diag: string }>`
   font-size: 13px;
   font-weight: 700;
 `;
+
+
+export const InstSevBadge = styled.span<{ $bg: string; $color: string; $border: string }>`
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 9px;
+  font-size: 9px;
+  font-weight: 600;
+  background: ${(p) => p.$bg};
+  color: ${(p) => p.$color};
+  border: 1px solid ${(p) => p.$border};
+  white-space: nowrap;
+  margin-left: 6px;
+  flex-shrink: 0;
+`;

--- a/src/features/nutritional/nutritionalUtils.ts
+++ b/src/features/nutritional/nutritionalUtils.ts
@@ -99,6 +99,12 @@ export function sevMNUTRIC(v: number): SeverityType {
   return "bx";
 }
 
+export const INST_STYLE: Record<string, { bg: string; color: string; border: string }> = {
+  cr: { bg: "#fcebeb", color: "#a32d2d", border: "#f09595" },
+  al: { bg: "#fdf3dc", color: "#b7770d", border: "#fac775" },
+  md: { bg: "#f0eeff", color: "#3c3489", border: "#b39ddb" },
+};
+
 export function sevNRS(v: number): SeverityType {
   if (v >= 5) return "cr";
   if (v >= 3) return "al";


### PR DESCRIPTION
## Descrição
Implementação dos chips e sinalização visual de instabilidade nutricional baseada na severidade dos alertas, atendendo aos requisitos da **US-FE-16**. O foco foi otimizar a visualização para que o nutricionista identifique alertas críticos sem precisar abrir o modal.

## O que foi alterado
- **Store (`NutritionalSlice.ts`)**: Atualizado o tipo `InstItem` para suportar o atributo `sev` (`'cr' | 'al' | 'md'`). Adicionada normalização de dados para precaver erros no contrato da API.
- **`PatientCard.tsx`**: 
  - Os chips de instabilidade agora renderizam suas cores baseadas na **severidade** em vez do tipo.
  - Implementado limite de exibição: máximo de 3 alertas visíveis. Caso existam mais, o excedente é agrupado em uma badge `+N`.
  - A cor da borda esquerda do card agora calcula e reflete a severidade mais alta entre os alertas ativos (não-reconhecidos).
- **`PatientModal.tsx`**: Na tab "Instabilidade", a antiga bolinha colorida foi substituída por uma badge detalhada indicando a severidade (Crítico, Alto, Médio) de cada alerta.


## Critérios de Aceite Atendidos
- [x] Tipo `InstItem` atualizado para `{ t: 'lab'|'clin'|'rx'; sev: 'cr'|'al'|'md'; d: string }`
- [x] Chips no `PatientCard` usam cor de `sev` (não de `t`)
- [x] Lista na tab Instabilidade do `PatientModal` exibe badge de severidade por item
- [x] Cor do card (borda esquerda na lista) reflete o `sev` mais alto entre os alertas ativos
- [x] `PatientCard`: máximo 3 chips visíveis + badge `+N` para excedentes
