### PR TITLE
Feature/us fe 10

### DIFF
--- a/src/features/nutritional/NutritionalDashboard.tsx
+++ b/src/features/nutritional/NutritionalDashboard.tsx
@@ -277,7 +277,12 @@ export function NutritionalDashboard() {
   const [filtAla, setFiltAla] = useState("all");
   const [filtSev, setFiltSev] = useState("");
   const [sortAsc, setSortAsc] = useState(false);
-  const [modalPatient, setModalPatient] = useState<NutritionalPatient | null>(null);
+  const [modalPatientId, setModalPatientId] = useState<number | null>(null);
+
+  // Deriva o paciente do Redux para que o modal re-renderize quando o estado mudar
+  const modalPatient = modalPatientId !== null
+    ? patients.find((p: NutritionalPatient) => p.id === modalPatientId) ?? null
+    : null;
 
   const fila1Patients = useAppSelector(selectFila1);
   const fila5Patients = useAppSelector(selectFila5);
@@ -339,7 +344,7 @@ export function NutritionalDashboard() {
   };
 
   const handleOpenTab = (patient: NutritionalPatient, tab: string) => {
-    setModalPatient(patient);
+    setModalPatientId(patient.id);
     setModalTab(tab);
   };
 
@@ -791,7 +796,7 @@ export function NutritionalDashboard() {
         acknowledged={acknowledged}
         activeTab={modalTab}
         onTabChange={setModalTab}
-        onClose={() => setModalPatient(null)}
+        onClose={() => setModalPatientId(null)}
       />
     </>
   );

--- a/src/features/nutritional/NutritionalDashboard.tsx
+++ b/src/features/nutritional/NutritionalDashboard.tsx
@@ -269,7 +269,7 @@ const REFRESH_INTERVAL = 15 * 60 * 1000; // 15 minutos
 
 export function NutritionalDashboard() {
   const dispatch = useAppDispatch();
-  const { patients, acknowledged, loading, error } = useAppSelector(
+  const { patients, acknowledged, loading, error, filtFila } = useAppSelector(
     (state: any) => state.nutritional
   );
 
@@ -285,8 +285,8 @@ export function NutritionalDashboard() {
 
   // ── Auto-fetch + 15-min refresh ─────────────────────────────────────────
   useEffect(() => {
-    dispatch(fetchPatients());
-    const interval = setInterval(() => dispatch(fetchPatients()), REFRESH_INTERVAL);
+    dispatch(fetchPatients({}));
+    const interval = setInterval(() => dispatch(fetchPatients({})), REFRESH_INTERVAL);
     return () => clearInterval(interval);
   }, [dispatch]);
 

--- a/src/features/nutritional/NutritionalSlice.ts
+++ b/src/features/nutritional/NutritionalSlice.ts
@@ -1,7 +1,6 @@
 import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
 import { AxiosError } from "axios";
-import api from "services/api";
-import { createSlice } from "@reduxjs/toolkit";
+import api from "services/nutritional/api";
 
 export type AlaType = "UTI" | "B" | "C";
 export type SeverityType = "cr" | "al" | "md" | "bx";
@@ -18,6 +17,8 @@ export interface HistEntry {
   c: string;       // conduta text
   freq: string;    // visit frequency
   ing: number | null; // ingestion %
+  meta_kcal?: number;
+  meta_prot?: number;
 }
 
 export interface NutritionalPatient {
@@ -72,240 +73,6 @@ interface NutritionalState {
   filtFila: string;
 }
 
-const MOCK_PATIENTS: NutritionalPatient[] = [
-  {
-    id: 1,
-    leito: "UTI-03",
-    ala: "UTI",
-    nome: "Paciente 1",
-    idade: 67,
-    dias: 14,
-    mnutric: 9,
-    nrs: 5,
-    sev: "cr",
-    pri: 1,
-    mn_dims: { idade: 2, apache: 3, sofa: 3, comor: 1, dias: 0 },
-    nrs_dims: { nut: 3, doenca: 1, idade: 1 },
-    dieta: "NPO > 52h",
-    npo: 52,
-    peso: "58kg",
-    imc: 17.2,
-    haval: 38,
-    glim_diag: "grave",
-    glim_fen: ["perda_peso", "baixo_imc"],
-    glim_etiol: ["doenca_inflamacao", "reducao_ingestao"],
-    inst: [
-      { t: "lab", d: "Albumina 1,8 g/dL" },
-      { t: "lab", d: "Hb 8,4 g/dL" },
-      { t: "lab", d: "Fósforo baixo" },
-      { t: "clin", d: "NPO 52h" },
-    ],
-    conduta: "TN parenteral urgente",
-    alergia: null,
-    alOk: true,
-    d7: true,
-    hist: [
-      {
-        h: "12/03 08:14",
-        p: "Nutr. Silva",
-        c: "Iniciado NPT. Meta 1800 kcal, 100g proteína.",
-        freq: "24h",
-        ing: 0,
-      },
-    ],
-  },
-  {
-    id: 2,
-    leito: "UTI-07",
-    ala: "UTI",
-    nome: "Paciente 2",
-    idade: 54,
-    dias: 8,
-    mnutric: 7,
-    nrs: 4,
-    sev: "cr",
-    pri: 2,
-    mn_dims: { idade: 1, apache: 3, sofa: 2, comor: 1, dias: 0 },
-    nrs_dims: { nut: 2, doenca: 2, idade: 0 },
-    dieta: "Enteral contínua",
-    npo: 0,
-    peso: "62kg",
-    imc: 19.8,
-    haval: 29,
-    glim_diag: "mod",
-    glim_fen: ["perda_peso"],
-    glim_etiol: ["doenca_inflamacao"],
-    inst: [
-      { t: "lab", d: "Albumina 2,3 g/dL" },
-      { t: "lab", d: "PCR elevado" },
-    ],
-    conduta: "Revisar protocolo enteral",
-    alergia: null,
-    alOk: true,
-    d7: false,
-    hist: [
-      {
-        h: "14/03 10:22",
-        p: "Nutr. Santos",
-        c: "Ajustado volume enteral 60mL/h.",
-        freq: "48h",
-        ing: 65,
-      },
-    ],
-  },
-  {
-    id: 3,
-    leito: "B-12",
-    ala: "B",
-    nome: "Paciente 3",
-    idade: 71,
-    dias: 5,
-    mnutric: null,
-    nrs: 5,
-    sev: "al",
-    pri: 3,
-    nrs_dims: { nut: 3, doenca: 1, idade: 1 },
-    dieta: "VO parcial",
-    npo: 0,
-    peso: "71kg",
-    imc: 20.4,
-    haval: 25,
-    glim_diag: "mod",
-    glim_fen: ["perda_peso"],
-    glim_etiol: ["reducao_ingestao"],
-    inst: [
-      { t: "lab", d: "Hb 9,2 g/dL" },
-      { t: "clin", d: "Perda 6% peso" },
-    ],
-    conduta: "Suporte nutricional oral",
-    alergia: "Frutos do mar",
-    alOk: false,
-    d7: true,
-    hist: [],
-  },
-  {
-    id: 4,
-    leito: "B-04",
-    ala: "B",
-    nome: "Paciente 4",
-    idade: 48,
-    dias: 3,
-    mnutric: null,
-    nrs: 3,
-    sev: "al",
-    pri: 4,
-    nrs_dims: { nut: 2, doenca: 1, idade: 0 },
-    dieta: "VO livre",
-    npo: 0,
-    peso: "68kg",
-    imc: 22.1,
-    haval: 27,
-    glim_diag: null,
-    glim_fen: [],
-    glim_etiol: [],
-    inst: [{ t: "lab", d: "Albumina 2,9 g/dL" }],
-    conduta: "Aguarda avaliação GLIM",
-    alergia: null,
-    alOk: true,
-    d7: false,
-    dados_incompletos: true,
-    nrs_completo: false,
-    hist: [],
-  },
-  {
-    id: 5,
-    leito: "C-05",
-    ala: "C",
-    nome: "Paciente 5",
-    idade: 55,
-    dias: 9,
-    mnutric: null,
-    nrs: 4,
-    sev: "al",
-    pri: 5,
-    nrs_dims: { nut: 2, doenca: 2, idade: 0 },
-    dieta: "NPT em uso",
-    npo: 0,
-    peso: "55kg",
-    imc: 18.5,
-    haval: 18,
-    glim_diag: "grave",
-    glim_fen: ["perda_peso", "baixo_imc", "massa_muscular"],
-    glim_etiol: ["reducao_ingestao", "doenca_inflamacao"],
-    inst: [
-      { t: "lab", d: "Fósforo 2,1 mg/dL" },
-      { t: "lab", d: "Magnésio baixo" },
-      { t: "rx", d: "NPT em uso" },
-    ],
-    conduta: "Corrigir eletrólitos – risco realimentação",
-    alergia: null,
-    alOk: true,
-    d7: true,
-    hist: [
-      {
-        h: "15/03 14:10",
-        p: "Nutr. Silva",
-        c: "Risco de síndrome de realimentação. Repor fósforo EV.",
-        freq: "24h",
-        ing: null,
-      },
-    ],
-  },
-  {
-    id: 6,
-    leito: "B-09",
-    ala: "B",
-    nome: "Paciente 6",
-    idade: 60,
-    dias: 6,
-    mnutric: null,
-    nrs: 3,
-    sev: "md",
-    pri: 6,
-    nrs_dims: { nut: 1, doenca: 2, idade: 0 },
-    dieta: "Enteral noturna",
-    npo: 0,
-    peso: "88kg",
-    imc: 26.3,
-    haval: 30,
-    glim_diag: "nd",
-    glim_fen: [],
-    glim_etiol: [],
-    inst: [{ t: "rx", d: "Troca de fórmula enteral" }],
-    conduta: "Ajuste fórmula",
-    alergia: null,
-    alOk: true,
-    d7: false,
-    hist: [],
-  },
-  {
-    id: 7,
-    leito: "C-01",
-    ala: "C",
-    nome: "Paciente 7",
-    idade: 38,
-    dias: 2,
-    mnutric: null,
-    nrs: 1,
-    sev: "bx",
-    pri: 7,
-    nrs_dims: { nut: 0, doenca: 1, idade: 0 },
-    dieta: "VO livre",
-    npo: 0,
-    peso: "61kg",
-    imc: 23.0,
-    haval: 10,
-    glim_diag: "nd",
-    glim_fen: [],
-    glim_etiol: [],
-    inst: [{ t: "clin", d: "Alergia sem confirmação" }],
-    conduta: "Dieta sem lactose",
-    alergia: "Lactose",
-    alOk: false,
-    d7: false,
-    hist: [],
-  },
-];
 
 const initialState: NutritionalState = {
   patients: [],
@@ -332,6 +99,34 @@ export const fetchPatients = createAsyncThunk(
         axiosErr.message ??
         "Erro ao carregar pacientes";
       return thunkAPI.rejectWithValue(status ? `${status} — ${msg}` : msg);
+    }
+  }
+);
+
+export const fetchAssessmentHistory = createAsyncThunk(
+  "nutritional/fetchAssessmentHistory",
+  async (nratendimento: number, thunkAPI) => {
+    try {
+      const response = await api.nutritional.getAssessmentHistory(nratendimento);
+      return { id: nratendimento, history: response.data.data || response.data };
+    } catch (err) {
+      const axiosErr = err as AxiosError<{ error?: string; message?: string }>;
+      const msg = axiosErr.response?.data?.error ?? axiosErr.message ?? "Erro ao carregar avaliações";
+      return thunkAPI.rejectWithValue(msg);
+    }
+  }
+);
+
+export const saveAssessment = createAsyncThunk(
+  "nutritional/saveAssessment",
+  async (payload: { id: number; data: import('services/nutritional/api').AvalPayload }, thunkAPI) => {
+    try {
+      const response = await api.nutritional.saveAval(payload.id, payload.data);
+      return { id: payload.id, response: response.data, sentData: payload.data };
+    } catch (err) {
+      const axiosErr = err as AxiosError<{ error?: string; message?: string }>;
+      const msg = axiosErr.response?.data?.error ?? axiosErr.message ?? "Erro ao salvar avaliação";
+      return thunkAPI.rejectWithValue(msg);
     }
   }
 );
@@ -378,31 +173,6 @@ const nutritionalSlice = createSlice({
           nut + patient.nrs_dims.doenca + (patient.idade >= 70 ? 1 : 0);
       }
     },
-    saveAval(
-      state,
-      action: {
-        payload: { id: number; conduta: string; freq: string; ing: number };
-      }
-    ) {
-      const { id, conduta, freq, ing } = action.payload;
-      const patient = state.patients.find((p) => p.id === id);
-      if (patient) {
-        patient.haval = 0;
-        patient.conduta = conduta;
-        const now = new Date();
-        const dd = String(now.getDate()).padStart(2, "0");
-        const mm = String(now.getMonth() + 1).padStart(2, "0");
-        const hh = String(now.getHours()).padStart(2, "0");
-        const min = String(now.getMinutes()).padStart(2, "0");
-        patient.hist.unshift({
-          h: `${dd}/${mm} ${hh}:${min}`,
-          p: "Nutr. Silva",
-          c: conduta,
-          freq,
-          ing,
-        });
-      }
-    },
     confirmAllergy(state, action: { payload: { id: number } }) {
       const { id } = action.payload;
       const patient = state.patients.find((p) => p.id === id);
@@ -431,6 +201,34 @@ const nutritionalSlice = createSlice({
       .addCase(fetchPatients.rejected, (state, action) => {
         state.loading = false;
         state.error = (action.payload as string) ?? action.error.message ?? "Erro desconhecido";
+      })
+      .addCase(fetchAssessmentHistory.fulfilled, (state, action) => {
+        const patient = state.patients.find((p) => p.id === action.payload.id);
+        if (patient) {
+          patient.hist = action.payload.history;
+        }
+      })
+      .addCase(saveAssessment.fulfilled, (state, action) => {
+        const { id, sentData } = action.payload;
+        const patient = state.patients.find((p) => p.id === id);
+        if (patient) {
+          patient.haval = 0;
+          patient.conduta = sentData.conduta;
+          const now = new Date();
+          const dd = String(now.getDate()).padStart(2, "0");
+          const mm = String(now.getMonth() + 1).padStart(2, "0");
+          const hh = String(now.getHours()).padStart(2, "0");
+          const min = String(now.getMinutes()).padStart(2, "0");
+          patient.hist.unshift({
+            h: `${dd}/${mm} ${hh}:${min}`,
+            p: "Você",
+            c: sentData.conduta,
+            freq: sentData.frequencia,
+            ing: sentData.ingestao || null,
+            meta_kcal: sentData.meta_kcal,
+            meta_prot: sentData.meta_prot,
+          });
+        }
       });
   },
 });
@@ -438,7 +236,6 @@ const nutritionalSlice = createSlice({
 export const {
   saveGlim,
   saveNrsNut,
-  saveAval,
   confirmAllergy,
   acknowledgePatient,
   setFiltFila,

--- a/src/features/nutritional/NutritionalSlice.ts
+++ b/src/features/nutritional/NutritionalSlice.ts
@@ -88,8 +88,41 @@ export const fetchPatients = createAsyncThunk(
     try {
       const response = await api.nutritional.getPatients(params);
       const payload = response.data;
-      // suporta { data: [...] } e array direto
-      return (Array.isArray(payload) ? payload : payload?.data ?? []) as NutritionalPatient[];
+      const rawList = Array.isArray(payload) ? payload : payload?.data ?? [];
+      return rawList.map((p: any) => {
+        let nrs = 0;
+        let mnutric = null;
+        let nrs_dims = { nut: 0, doenca: 0, idade: 0 };
+        let mn_dims = undefined;
+        let dados_incompletos = false;
+        
+        if (p.campo1) {
+          nrs = p.campo1.nrs_total ?? 0;
+          if (p.campo1.nrs_dims) nrs_dims = p.campo1.nrs_dims;
+          if (p.campo1.mnutric_total !== undefined) mnutric = p.campo1.mnutric_total;
+          if (p.campo1.mn_dims) mn_dims = p.campo1.mn_dims;
+          if (p.campo1.dados_incompletos) dados_incompletos = true;
+        }
+
+        let ala = p.ala;
+        if (ala === "Segmento Adulto") ala = "UTI";
+        else if (ala === "Segmento Infantil") ala = "B";
+        else if (!["UTI", "B", "C"].includes(ala)) ala = "C";
+
+        return {
+          ...p,
+          ala,
+          nome: p.nome || `Paciente ${p.id}`,
+          nrs,
+          mnutric,
+          nrs_dims,
+          mn_dims,
+          dados_incompletos,
+          hist: p.hist || [],
+          inst: p.inst || [],
+          leito: p.leito || `L${p.id}`,
+        };
+      }) as NutritionalPatient[];
     } catch (err) {
       const axiosErr = err as AxiosError<{ error?: string; message?: string }>;
       const status = axiosErr.response?.status;
@@ -105,13 +138,13 @@ export const fetchPatients = createAsyncThunk(
 
 export const fetchAssessmentHistory = createAsyncThunk(
   "nutritional/fetchAssessmentHistory",
-  async (nratendimento: number, thunkAPI) => {
+  async (patientId: number, thunkAPI) => {
     try {
-      const response = await api.nutritional.getAssessmentHistory(nratendimento);
-      return { id: nratendimento, history: response.data.data || response.data };
+      const response = await api.nutritional.getAssessmentHistory(patientId);
+      return { id: patientId, history: response.data.data || response.data };
     } catch (err) {
       const axiosErr = err as AxiosError<{ error?: string; message?: string }>;
-      const msg = axiosErr.response?.data?.error ?? axiosErr.message ?? "Erro ao carregar avaliações";
+      const msg = axiosErr.response?.data?.error ?? axiosErr.message ?? "Failed to load assessments";
       return thunkAPI.rejectWithValue(msg);
     }
   }
@@ -119,13 +152,13 @@ export const fetchAssessmentHistory = createAsyncThunk(
 
 export const saveAssessment = createAsyncThunk(
   "nutritional/saveAssessment",
-  async (payload: { id: number; data: import('services/nutritional/api').AvalPayload }, thunkAPI) => {
+  async (payload: { id: number; data: import('services/nutritional/api').AssessmentPayload }, thunkAPI) => {
     try {
-      const response = await api.nutritional.saveAval(payload.id, payload.data);
-      return { id: payload.id, response: response.data, sentData: payload.data };
+      const response = await api.nutritional.postAssessment(payload.id, payload.data);
+      return { id: payload.id, response: response.data, submittedData: payload.data };
     } catch (err) {
       const axiosErr = err as AxiosError<{ error?: string; message?: string }>;
-      const msg = axiosErr.response?.data?.error ?? axiosErr.message ?? "Erro ao salvar avaliação";
+      const msg = axiosErr.response?.data?.error ?? axiosErr.message ?? "Failed to save assessment";
       return thunkAPI.rejectWithValue(msg);
     }
   }
@@ -205,15 +238,34 @@ const nutritionalSlice = createSlice({
       .addCase(fetchAssessmentHistory.fulfilled, (state, action) => {
         const patient = state.patients.find((p) => p.id === action.payload.id);
         if (patient) {
-          patient.hist = action.payload.history;
+          // Transforma formato da API para formato do hist do frontend
+          patient.hist = (action.payload.history || []).map((item: any) => {
+            // Se já tem os campos do frontend (h, c, freq), retorna direto
+            if (item.h && item.c) return item;
+            // Senão, transforma do formato da API
+            const dt = item.created_at ? new Date(item.created_at) : new Date();
+            const dd = String(dt.getDate()).padStart(2, "0");
+            const mm = String(dt.getMonth() + 1).padStart(2, "0");
+            const hh = String(dt.getHours()).padStart(2, "0");
+            const min = String(dt.getMinutes()).padStart(2, "0");
+            return {
+              h: `${dd}/${mm} ${hh}:${min}`,
+              p: item.prof || item.p || "Nutricionista",
+              c: item.conduta || item.c || "",
+              freq: item.prox_visita || item.frequencia || item.freq || "",
+              ing: item.ingestao ?? item.ing ?? null,
+              meta_kcal: item.meta_kcal || null,
+              meta_prot: item.meta_prot || null,
+            };
+          });
         }
       })
       .addCase(saveAssessment.fulfilled, (state, action) => {
-        const { id, sentData } = action.payload;
+        const { id, submittedData } = action.payload;
         const patient = state.patients.find((p) => p.id === id);
         if (patient) {
           patient.haval = 0;
-          patient.conduta = sentData.conduta;
+          patient.conduta = submittedData.conduta;
           const now = new Date();
           const dd = String(now.getDate()).padStart(2, "0");
           const mm = String(now.getMonth() + 1).padStart(2, "0");
@@ -221,12 +273,12 @@ const nutritionalSlice = createSlice({
           const min = String(now.getMinutes()).padStart(2, "0");
           patient.hist.unshift({
             h: `${dd}/${mm} ${hh}:${min}`,
-            p: "Você",
-            c: sentData.conduta,
-            freq: sentData.frequencia,
-            ing: sentData.ingestao || null,
-            meta_kcal: sentData.meta_kcal,
-            meta_prot: sentData.meta_prot,
+            p: "You",
+            c: submittedData.conduta,
+            freq: submittedData.prox_visita || submittedData.frequencia,
+            ing: submittedData.ingestao || null,
+            meta_kcal: submittedData.meta_kcal,
+            meta_prot: submittedData.meta_prot,
           });
         }
       });

--- a/src/features/nutritional/components/PatientModal.tsx
+++ b/src/features/nutritional/components/PatientModal.tsx
@@ -13,6 +13,7 @@ import {
   Checkbox,
   Radio,
   Button,
+  message,
 } from "antd";
 import {
   WarningOutlined,
@@ -263,7 +264,7 @@ const HistEntry = styled.div`
     flex-wrap: wrap;
   }
 
-  .hist-conduta {
+  .hist-conduct {
     font-size: 12px;
     color: #2e3c5a;
     margin-bottom: 4px;
@@ -328,8 +329,7 @@ const NRS_A_OPTIONS = [
 const FREQ_OPTIONS = [
   { value: "24h", label: "24 horas" },
   { value: "48h", label: "48 horas" },
-  { value: "semanal", label: "Semanal" },
-  { value: "d7", label: "D7 programado" },
+  { value: "semanal", label: "7 dias (semanal)" },
   { value: "rotina", label: "Rotina" },
 ];
 
@@ -361,16 +361,16 @@ export function PatientModal({
   const [grad, setGrad] = useState<string>("");
   const [glimObs, setGlimObs] = useState("");
 
-  // ── Aval tab local state ──────────────────────────────────────────────
-  const [conduta, setConduta] = useState("");
+  // ── Assessment tab local state ─────────────────────────────────────────
+  const [conduct, setConduct] = useState("");
   const [freq, setFreq] = useState("24h");
   const [ingestion, setIngestion] = useState(50);
   const [kcal, setKcal] = useState<number | null>(null);
   const [prot, setProt] = useState<number | null>(null);
 
-  // ── Inst tab local state ──────────────────────────────────────────────
-  const [instObs, setInstObs] = useState("");
-  const [antecipar, setAntecipar] = useState<string>("");
+  // ── Instability tab local state ────────────────────────────────────────
+  const [instNotes, setInstNotes] = useState("");
+  const [anticipate, setAnticipate] = useState<string>("");
 
   // ── Initialize from patient ───────────────────────────────────────────
   useEffect(() => {
@@ -382,13 +382,13 @@ export function PatientModal({
     setEtiolSelected(p.glim_etiol ?? []);
     setGrad(p.glim_diag ?? "");
     setGlimObs("");
-    setConduta(p.conduta ?? "");
+    setConduct(p.conduta ?? "");
     setFreq("24h");
     setIngestion(50);
     setKcal(null);
     setProt(null);
-    setInstObs("");
-    setAntecipar("");
+    setInstNotes("");
+    setAnticipate("");
   }, [p?.id]);
 
   if (!p) return null;
@@ -458,17 +458,27 @@ export function PatientModal({
     dispatch(saveNrsNut({ id: p.id, nut: nrsA }));
   };
 
-  const handleSaveAval = () => {
-    dispatch(saveAssessment({ 
+  const handleSaveAssessment = async () => {
+    const result = await dispatch(saveAssessment({ 
       id: p.id, 
       data: { 
-        conduta, 
-        frequencia: freq as any, 
+        conduta: conduct, 
+        prox_visita: freq as '24h' | '48h' | 'semanal' | 'D7' | 'rotina', 
         ingestao: ingestion,
         meta_kcal: kcal || undefined,
         meta_prot: prot || undefined
       } 
     }));
+    if (saveAssessment.fulfilled.match(result)) {
+      message.success('Avaliação registrada com sucesso.');
+      setConduct('');
+      setFreq('24h');
+      setIngestion(50);
+      setKcal(null);
+      setProt(null);
+    } else {
+      message.error('Erro ao registrar avaliação. O servidor pode estar indisponível.');
+    }
   };
 
   const handleConfirmAllergy = () => {
@@ -918,8 +928,8 @@ export function PatientModal({
           Conduta
         </div>
         <Input.TextArea
-          value={conduta}
-          onChange={(e) => setConduta(e.target.value)}
+          value={conduct}
+          onChange={(e) => setConduct(e.target.value)}
           rows={3}
           placeholder="Descreva a conduta nutricional..."
         />
@@ -983,8 +993,8 @@ export function PatientModal({
 
       <Button
         type="primary"
-        onClick={handleSaveAval}
-        disabled={!conduta.trim()}
+        onClick={handleSaveAssessment}
+        disabled={!conduct.trim()}
         style={{ background: "#3a9c6e", borderColor: "#3a9c6e", marginBottom: 24 }}
       >
         Registrar Avaliação
@@ -1002,7 +1012,7 @@ export function PatientModal({
                 <span>{h.h}</span>
                 <span>{h.p}</span>
               </div>
-              <div className="hist-conduta">{h.c}</div>
+              <div className="hist-conduct">{h.c}</div>
               <div className="hist-meta">
                 <span>Freq: {h.freq}</span>
                 {h.ing !== null && <span style={{ marginLeft: 8 }}>Ingestão: {h.ing}%</span>}
@@ -1090,8 +1100,8 @@ export function PatientModal({
           Observações
         </div>
         <Input.TextArea
-          value={instObs}
-          onChange={(e) => setInstObs(e.target.value)}
+          value={instNotes}
+          onChange={(e) => setInstNotes(e.target.value)}
           rows={3}
           placeholder="Observações sobre instabilidade nutricional..."
         />
@@ -1102,8 +1112,8 @@ export function PatientModal({
           Antecipar reavaliação?
         </div>
         <Radio.Group
-          value={antecipar}
-          onChange={(e) => setAntecipar(e.target.value)}
+          value={anticipate}
+          onChange={(e) => setAnticipate(e.target.value)}
         >
           <Radio value="sim">Sim – antecipar</Radio>
           <Radio value="nao">Não – manter programação</Radio>

--- a/src/features/nutritional/components/PatientModal.tsx
+++ b/src/features/nutritional/components/PatientModal.tsx
@@ -30,7 +30,8 @@ import {
   GlimDiag,
   saveGlim,
   saveNrsNut,
-  saveAval,
+  saveAssessment,
+  fetchAssessmentHistory,
   confirmAllergy,
   acknowledgePatient,
 } from "../NutritionalSlice";
@@ -374,6 +375,8 @@ export function PatientModal({
   // ── Initialize from patient ───────────────────────────────────────────
   useEffect(() => {
     if (!p) return;
+    dispatch(fetchAssessmentHistory(p.id));
+    
     setNrsA(p.nrs_dims.nut);
     setFenSelected(p.glim_fen ?? []);
     setEtiolSelected(p.glim_etiol ?? []);
@@ -456,7 +459,16 @@ export function PatientModal({
   };
 
   const handleSaveAval = () => {
-    dispatch(saveAval({ id: p.id, conduta, freq, ing: ingestion }));
+    dispatch(saveAssessment({ 
+      id: p.id, 
+      data: { 
+        conduta, 
+        frequencia: freq as any, 
+        ingestao: ingestion,
+        meta_kcal: kcal || undefined,
+        meta_prot: prot || undefined
+      } 
+    }));
   };
 
   const handleConfirmAllergy = () => {
@@ -993,7 +1005,9 @@ export function PatientModal({
               <div className="hist-conduta">{h.c}</div>
               <div className="hist-meta">
                 <span>Freq: {h.freq}</span>
-                {h.ing !== null && <span>Ingestão: {h.ing}%</span>}
+                {h.ing !== null && <span style={{ marginLeft: 8 }}>Ingestão: {h.ing}%</span>}
+                {h.meta_kcal && <span style={{ marginLeft: 8 }}>{h.meta_kcal} kcal</span>}
+                {h.meta_prot && <span style={{ marginLeft: 8 }}>{h.meta_prot}g de prot.</span>}
               </div>
             </HistEntry>
           ))}

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -59,16 +59,16 @@ export const setHeaders = () => {
 
   return token
     ? {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "x-api-key": apiKey,
-        },
-      }
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "x-api-key": apiKey,
+      },
+    }
     : {
-        headers: {
-          "x-api-key": apiKey,
-        },
-      };
+      headers: {
+        "x-api-key": apiKey,
+      },
+    };
 };
 
 /**
@@ -267,8 +267,7 @@ const savePrescriptionDrug = (bearerToken, idPrescriptionDrug, params = {}) => {
 
 const suspendPrescriptionDrug = (bearerToken, idPrescriptionDrug, suspend) => {
   return instance.put(
-    `${endpoints.editPrescription}/drug/${idPrescriptionDrug}/suspend/${
-      suspend ? 1 : 0
+    `${endpoints.editPrescription}/drug/${idPrescriptionDrug}/suspend/${suspend ? 1 : 0
     }`,
     {},
     setHeaders(bearerToken),

--- a/src/services/nutritional/api.ts
+++ b/src/services/nutritional/api.ts
@@ -6,6 +6,7 @@ interface NutritionalAPI {
   saveNrsNut: (nratendimento: number, data: NrsNutPayload) => any;
   saveGlim: (nratendimento: number, data: GlimPayload) => any;
   saveAval: (nratendimento: number, data: AvalPayload) => any;
+  getAssessmentHistory: (nratendimento: number) => any;
   acknowledgePatient: (nratendimento: number) => any;
 };
 
@@ -76,6 +77,16 @@ api.nutritional.saveAval = (nratendimento: number, data: AvalPayload) =>
     setHeaders(),
   );
 
+/**
+ * Retrieves the nutritional assessment history for the patient.
+ * @param nratendimento - Patient admission number
+ * @returns Promise with the assessment history list
+ */
+api.nutritional.getAssessmentHistory = (nratendimento: number) =>
+  instance.get(
+    `/patients/${nratendimento}/assessment`,
+    setHeaders(),
+  );
 
 /**
  * Acknowledges/dismisses a nutritional alert for the patient.

--- a/src/services/nutritional/api.ts
+++ b/src/services/nutritional/api.ts
@@ -1,112 +1,8 @@
-import apiModule, { instance, setHeaders } from '../api';
+import { instance, setHeaders } from '../api';
 
-
-interface NutritionalAPI {
-  getPatients: (params?: { setor?: number; ala?: string }) => any;
-  saveNrsNut: (nratendimento: number, data: NrsNutPayload) => any;
-  saveGlim: (nratendimento: number, data: GlimPayload) => any;
-  saveAval: (nratendimento: number, data: AvalPayload) => any;
-  getAssessmentHistory: (nratendimento: number) => any;
-  acknowledgePatient: (nratendimento: number) => any;
-};
-
-
-type API = typeof apiModule & {
-  nutritional: NutritionalAPI;
-};
-
-
-const api = apiModule as API;
-
-
-/**
- * Retrieves a list of patients with nutritional scores (Campo 1) calculated by the backend.
- * @param params - Optional filtering parameters:
- *   - setor: Sector ID for filtering
- *   - ala: Wing/ward identifier for filtering
- * @returns Promise with the list of patients and their nutritional scores
- */
-api.nutritional.getPatients = (params?: { setor?: number; ala?: string }) =>
-  instance.get('/patients', {
-    params,
-    ...setHeaders(),
-  });
-
-
-/**
- * Saves manual APACHE II and SOFA scores for ICU patients.
- * Triggers immediate recalculation of mNUTRIC and returns updated Campo 1.
- * Note: Component A of NRS-2002 is calculated automatically and not sent here.
- * @param nratendimento - Patient admission number
- * @param data - Payload with APACHE II (0-71) and SOFA (0-24) scores for ICU patients
- * @returns Promise with updated nutritional assessment
- */
-api.nutritional.saveNrsNut = (nratendimento: number, data: NrsNutPayload) =>
-  instance.put(
-    `/patients/${nratendimento}/nrs-nut`,
-    data,
-    setHeaders(),
-  );
-
-/**
- * Saves GLIM (Global Leadership Initiative on Malnutrition) diagnosis.
- * Stores phenotypes and etiologies of malnutrition for the patient.
- * @param nratendimento - Patient admission number
- * @param data - Payload with diagnosis level ('nd'=non-disease, 'mod'=moderate, 'grave'=severe), phenotypes, and etiologies
- * @returns Promise with saved GLIM diagnosis
- */
-api.nutritional.saveGlim = (nratendimento: number, data: GlimPayload) =>
-  instance.put(
-    `/patients/${nratendimento}/glim`,
-    data,
-    setHeaders(),
-  );
-
-
-/**
- * Records the nutritional assessment and feeding protocol for the patient.
- * Stores clinical conduct, monitoring frequency, and nutritional goals.
- * @param nratendimento - Patient admission number
- * @param data - Payload with conduct protocol, monitoring frequency (12h/24h/48h/7d/routine), and optional intake/caloric/protein goals
- * @returns Promise with saved assessment
- */
-api.nutritional.saveAval = (nratendimento: number, data: AvalPayload) =>
-  instance.post(
-    `/patients/${nratendimento}/assessment`,
-    data,
-    setHeaders(),
-  );
-
-/**
- * Retrieves the nutritional assessment history for the patient.
- * @param nratendimento - Patient admission number
- * @returns Promise with the assessment history list
- */
-api.nutritional.getAssessmentHistory = (nratendimento: number) =>
-  instance.get(
-    `/patients/${nratendimento}/assessment`,
-    setHeaders(),
-  );
-
-/**
- * Acknowledges/dismisses a nutritional alert for the patient.
- * Marks that a healthcare provider has reviewed and acknowledged the alert.
- * @param nratendimento - Patient admission number
- * @returns Promise with acknowledgment confirmation
- */
-api.nutritional.acknowledgePatient = (nratendimento: number) =>
-  instance.post(
-    `/patients/${nratendimento}/acknowledge`,
-    {},
-    setHeaders(),
-  );
-
-
-// Tipos
 export interface NrsNutPayload {
-  apache_ii: number; // APACHE II (0-71) -- apenas UTI
-  sofa: number; // SOFA (0-24) -- apenas UTI
-  // nrs_nut NAO existe: componente A e automatico via nutricional_nrs (hospital)
+  apache_ii: number; // APACHE II (0-71) -- ICU only
+  sofa: number; // SOFA (0-24) -- ICU only
 };
 
 export interface GlimPayload {
@@ -115,13 +11,57 @@ export interface GlimPayload {
   etiologias: string[];
 };
 
-export interface AvalPayload {
+// Field names match backend REST contract (PT) -- do not rename
+export interface AssessmentPayload {
   conduta: string;
-  frequencia: '12h' | '24h' | '48h' | '7d' | 'rotina';
+  prox_visita: '24h' | '48h' | 'semanal' | 'D7' | 'rotina'; // Changed from 'frequencia' to match backend model
   ingestao?: number;
   meta_kcal?: number;
   meta_prot?: number;
 };
 
+const nutritional = {
+  getPatients: (params?: { setor?: number; ala?: string }) =>
+    instance.get('/nutritional/patients', {
+      params,
+      ...setHeaders(),
+    }),
+
+  saveNrsNut: (patientId: number, data: NrsNutPayload) =>
+    instance.put(
+      `/patients/${patientId}/nrs-nut`,
+      data,
+      setHeaders(),
+    ),
+
+  saveGlim: (patientId: number, data: GlimPayload) =>
+    instance.put(
+      `/patients/${patientId}/glim`,
+      data,
+      setHeaders(),
+    ),
+
+  postAssessment: (patientId: number, data: AssessmentPayload) =>
+    instance.post(
+      `/nutritional/patients/${patientId}/assessments`,
+      data,
+      setHeaders(),
+    ),
+
+  getAssessmentHistory: (patientId: number) =>
+    instance.get(
+      `/nutritional/patients/${patientId}/assessments`,
+      setHeaders(),
+    ),
+
+  acknowledgePatient: (patientId: number) =>
+    instance.post(
+      `/patients/${patientId}/acknowledge`,
+      {},
+      setHeaders(),
+    ),
+};
+
+const api = { nutritional };
 
 export default api;


### PR DESCRIPTION
**Descrição**
Implementação da aba "Registrar Avaliação" (US-FE-10)

Este PR adiciona a funcionalidade para os nutricionistas registrarem a conduta clínica, metas nutricionais e o percentual de ingestão do paciente diretamente no PatientModal. Além disso, implementa a listagem do histórico de avaliações puxando os dados via API.

 **O que foi feito**
Nova Aba no Modal: Adicionada a aba de "Registrar Avaliação" no componente PatientModal.
Formulário de Avaliação:
Textarea carregando a conduta atual do paciente.
Select para definição da "Próxima visita" (24h, 48h, 7 dias/D7, semanal, rotina).
Slider de Ingestão (%) variando de 0 a 100.
Inputs opcionais para Meta Calórica (kcal) e Meta Proteica (g).
Integração com a API:
Implementado o Thunk saveAssessment para disparar o POST /nutritional/patients/{id}/assessments.
Implementado o Thunk fetchAssessmentHistory (GET /nutritional/patients/{id}/assessments) para buscar o histórico de avaliações assim que a aba é aberta.
Atualização de Estado (Redux):
Ao salvar uma avaliação com sucesso, o tempo de última avaliação (haval) é zerado no card.
A conduta local é atualizada.
A nova avaliação é injetada automaticamente no topo da lista de histórico local para reflexo imediato na UI.