### PR TITLE
fix(rf12): color inst chips and dots by sev instead of t

### DIFF
--- a/src/features/nutritional/NutritionalSlice.ts
+++ b/src/features/nutritional/NutritionalSlice.ts
@@ -11,7 +11,7 @@ export interface InstItem {
   t: "lab" | "clin" | "rx";
   d: string;
   ack: boolean;
-  sev?: SeverityType;
+  sev: SeverityType;
 }
 
 export interface HistEntry {
@@ -131,7 +131,7 @@ function normalizeApiPatient(raw: any): NutritionalPatient {
       t: i.t,
       d: i.d,
       ack: i.ack ?? false,
-      sev: i.sev ?? undefined,
+      sev: (i.sev ?? "md") as SeverityType,
     })),
     conduta: raw.conduta ?? "",
     alergia: raw.alergia ?? null,

--- a/src/features/nutritional/NutritionalSlice.ts
+++ b/src/features/nutritional/NutritionalSlice.ts
@@ -195,7 +195,7 @@ export const fetchAlerts = createAsyncThunk(
       const raw: any[] = Array.isArray(response.data) ? response.data : response.data?.data ?? []; // eslint-disable-line @typescript-eslint/no-explicit-any
       return {
         patientId,
-        alerts: raw.map((i: any) => ({ id: i.id ?? 0, t: i.t, d: i.d, ack: i.ack ?? false })), // eslint-disable-line @typescript-eslint/no-explicit-any
+        alerts: raw.map((i: any) => ({ id: i.id ?? 0, t: i.t, d: i.d, ack: i.ack ?? false, sev: (i.sev ?? "md") as SeverityType })), // eslint-disable-line @typescript-eslint/no-explicit-any
       };
     } catch (err) {
       const axiosErr = err as AxiosError<{ error?: string; message?: string }>;

--- a/src/features/nutritional/components/PatientCard/PatientCard.tsx
+++ b/src/features/nutritional/components/PatientCard/PatientCard.tsx
@@ -2,6 +2,7 @@ import { CheckCircleFilled } from "@ant-design/icons";
 import {
   NutritionalPatient,
   AcknowledgedEntry,
+  SeverityType,
 } from "../../NutritionalSlice";
 import { FeatureService } from "src/services/FeatureService";
 import Feature from "src/models/Feature";
@@ -23,11 +24,14 @@ interface PatientCardProps {
   onOpenTab: (tab: string) => void;
 }
 
-const INST_STYLE: Record<string, { bg: string; color: string; border: string }> = {
-  lab: { bg: "#fcebeb", color: "#a32d2d", border: "#f09595" },
-  clin: { bg: "#fdf3dc", color: "#b7770d", border: "#fac775" },
-  rx: { bg: "#f0eeff", color: "#3c3489", border: "#b39ddb" },
+const INST_STYLE: Record<SeverityType, { bg: string; color: string; border: string }> = {
+  cr: { bg: "#fcebeb", color: "#a32d2d", border: "#f09595" },
+  al: { bg: "#fdf3dc", color: "#b7770d", border: "#fac775" },
+  md: { bg: "#f0eeff", color: "#3c3489", border: "#b39ddb" },
+  bx: { bg: "#f6ffed", color: "#389e0d", border: "#b7eb8f" },
 };
+
+const SEV_ORDER: Record<SeverityType, number> = { cr: 3, al: 2, md: 1, bx: 0 };
 
 export function PatientCard({
   patient: p,
@@ -56,6 +60,12 @@ export function PatientCard({
 
   const instSlice = p.inst.slice(0, 3);
   const instMore = p.inst.length > 3 ? p.inst.length - 3 : 0;
+  const maxInstSev: SeverityType | null = p.inst.length > 0
+    ? p.inst.reduce<SeverityType>(
+        (max, i) => SEV_ORDER[i.sev] > SEV_ORDER[max] ? i.sev : max,
+        "bx"
+      )
+    : null;
 
   return (
     <Card $sev={p.sev} $atend={isAtend}>
@@ -162,10 +172,12 @@ export function PatientCard({
         {/* Campo 3 – Instabilidade */}
         {p.inst.length > 0 && (
           <>
-            <SectionLabel>Campo 3 – Instabilidade</SectionLabel>
+            <SectionLabel style={{ color: maxInstSev ? INST_STYLE[maxInstSev].color : undefined }}>
+              Campo 3 – Instabilidade
+            </SectionLabel>
             <TagsRow>
               {instSlice.map((item, i) => {
-                const st = INST_STYLE[item.t] ?? INST_STYLE.lab;
+                const st = INST_STYLE[item.sev] ?? INST_STYLE.md;
                 return (
                   <Tooltip key={i} title={item.d}>
                     <Badge $bg={st.bg} $color={st.color} $border={st.border}>

--- a/src/features/nutritional/components/PatientCard/PatientCard.tsx
+++ b/src/features/nutritional/components/PatientCard/PatientCard.tsx
@@ -8,6 +8,7 @@ import { FeatureService } from "src/services/FeatureService";
 import Feature from "src/models/Feature";
 import {
   SEV_CONFIG,
+  INST_STYLE,
   calcMbcd,
   sevMNUTRIC,
   sevNRS,
@@ -23,13 +24,6 @@ interface PatientCardProps {
   onClick: () => void;
   onOpenTab: (tab: string) => void;
 }
-
-const INST_STYLE: Record<SeverityType, { bg: string; color: string; border: string }> = {
-  cr: { bg: "#fcebeb", color: "#a32d2d", border: "#f09595" },
-  al: { bg: "#fdf3dc", color: "#b7770d", border: "#fac775" },
-  md: { bg: "#f0eeff", color: "#3c3489", border: "#b39ddb" },
-  bx: { bg: "#f6ffed", color: "#389e0d", border: "#b7eb8f" },
-};
 
 const SEV_ORDER: Record<SeverityType, number> = { cr: 3, al: 2, md: 1, bx: 0 };
 
@@ -58,17 +52,18 @@ export function PatientCard({
           ? "#3a9c6e"
           : "#d4931a";
 
-  const instSlice = p.inst.slice(0, 3);
-  const instMore = p.inst.length > 3 ? p.inst.length - 3 : 0;
-  const maxInstSev: SeverityType | null = p.inst.length > 0
-    ? p.inst.reduce<SeverityType>(
-        (max, i) => SEV_ORDER[i.sev] > SEV_ORDER[max] ? i.sev : max,
+  const activeInst = p.inst.filter((i) => !i.ack);
+  const instSlice = activeInst.slice(0, 3);
+  const instMore = activeInst.length > 3 ? activeInst.length - 3 : 0;
+  const maxInstSev: SeverityType | null = activeInst.length > 0
+    ? activeInst.reduce<SeverityType>(
+        (max, i) => SEV_ORDER[i.sev ?? "bx"] > SEV_ORDER[max] ? (i.sev ?? "bx") : max,
         "bx"
       )
     : null;
 
   return (
-    <Card $sev={p.sev} $atend={isAtend}>
+    <Card $sev={maxInstSev ?? p.sev} $atend={isAtend}>
       <CardBody onClick={onClick}>
         <CardTop>
           <BedLabel>{p.leito}</BedLabel>
@@ -170,7 +165,7 @@ export function PatientCard({
         </GlimText>
 
         {/* Campo 3 – Instabilidade */}
-        {p.inst.length > 0 && (
+        {activeInst.length > 0 && (
           <>
             <SectionLabel style={{ color: maxInstSev ? INST_STYLE[maxInstSev].color : undefined }}>
               Campo 3 – Instabilidade

--- a/src/features/nutritional/components/PatientModal/PatientModal.tsx
+++ b/src/features/nutritional/components/PatientModal/PatientModal.tsx
@@ -49,9 +49,10 @@ import { InfoBlock, SectionTitle, ScorePanel, ScorePanelTitle, ScorePanelValue, 
 
 
 const INST_DOT_COLOR: Record<string, string> = {
-  lab: "#e24b4a",
-  clin: "#d4931a",
-  rx: "#7e57c2",
+  cr: "#a32d2d",
+  al: "#b7770d",
+  md: "#3c3489",
+  bx: "#8c8c8c",
 };
 
 const INST_TYPE_LABEL: Record<string, string> = {
@@ -459,7 +460,7 @@ export function PatientModal({
           <InstPanel style={{ marginBottom: 12 }}>
             {p.inst.map((item, i) => (
               <InstItemRow key={i}>
-                <InstDot $color={INST_DOT_COLOR[item.t] ?? "#8c8c8c"} />
+                <InstDot $color={INST_DOT_COLOR[item.sev] ?? "#8c8c8c"} />
                 <span>{item.d}</span>
                 <InstTypeLabel>{INST_TYPE_LABEL[item.t] ?? item.t}</InstTypeLabel>
               </InstItemRow>
@@ -835,7 +836,7 @@ export function PatientModal({
           <InstPanel style={{ marginBottom: 16 }}>
             {activeLab.map((item) => (
               <InstItemRow key={item.id}>
-                <InstDot $color={INST_DOT_COLOR.lab} />
+                <InstDot $color={INST_DOT_COLOR[item.sev] ?? "#8c8c8c"} />
                 <span style={{ flex: 1 }}>{item.d}</span>
                 <InstTypeLabel>Laboratório</InstTypeLabel>
                 <Button
@@ -859,7 +860,7 @@ export function PatientModal({
           <InstPanel style={{ marginBottom: 16 }}>
             {activeClinRx.map((item) => (
               <InstItemRow key={item.id}>
-                <InstDot $color={INST_DOT_COLOR[item.t] ?? "#8c8c8c"} />
+                <InstDot $color={INST_DOT_COLOR[item.sev] ?? "#8c8c8c"} />
                 <span style={{ flex: 1 }}>{item.d}</span>
                 <InstTypeLabel>{INST_TYPE_LABEL[item.t] ?? item.t}</InstTypeLabel>
                 <Button

--- a/src/features/nutritional/nutritionalUtils.ts
+++ b/src/features/nutritional/nutritionalUtils.ts
@@ -94,6 +94,13 @@ export const GLIM_ETIOL_LABEL: Record<string, string> = {
   doenca_cronica:   "Doença crônica",       // chave retornada pela API
 };
 
+export const INST_STYLE: Record<SeverityType, { bg: string; color: string; border: string }> = {
+  cr: { bg: "#fcebeb", color: "#a32d2d", border: "#f09595" },
+  al: { bg: "#fdf3dc", color: "#b7770d", border: "#fac775" },
+  md: { bg: "#f0eeff", color: "#3c3489", border: "#b39ddb" },
+  bx: { bg: "#f6ffed", color: "#389e0d", border: "#b7eb8f" },
+};
+
 // ── Fila predicates — single source of truth ────────────────────────────────
 // Used by both the Redux selectors and matchFila; change criteria in one place.
 

--- a/src/store/selectors/__tests__/nutritionalSelectors.test.ts
+++ b/src/store/selectors/__tests__/nutritionalSelectors.test.ts
@@ -60,7 +60,7 @@ describe("isFila3", () => {
       inst: [
         { id: 1, t: "lab",  d: "A", ack: false, sev: "md" },
         { id: 2, t: "clin", d: "B", ack: false, sev: "bx" },
-        { id: 3, t: "rx",   d: "C", ack: false },
+        { id: 3, t: "rx",   d: "C", ack: false, sev: "md" as const },
       ],
     });
     expect(isFila3(p)).toBe(true);
@@ -69,10 +69,10 @@ describe("isFila3", () => {
   it("retorna true quando inst.length > 3", () => {
     const p = makePatient({
       inst: [
-        { id: 1, t: "lab", d: "A", ack: false },
-        { id: 2, t: "lab", d: "B", ack: false },
-        { id: 3, t: "lab", d: "C", ack: false },
-        { id: 4, t: "lab", d: "D", ack: false },
+        { id: 1, t: "lab", d: "A", ack: false, sev: "md" as const },
+        { id: 2, t: "lab", d: "B", ack: false, sev: "md" as const },
+        { id: 3, t: "lab", d: "C", ack: false, sev: "md" as const },
+        { id: 4, t: "lab", d: "D", ack: false, sev: "md" as const },
       ],
     });
     expect(isFila3(p)).toBe(true);
@@ -130,9 +130,9 @@ describe("selectFila3", () => {
     const p1 = makePatient({ id: 1, inst: [{ id: 1, t: "lab", d: "X", ack: false, sev: "cr" }] });
     const p2 = makePatient({ id: 2, inst: [] });
     const p3 = makePatient({ id: 3, inst: [
-      { id: 2, t: "lab",  d: "Y", ack: false },
-      { id: 3, t: "lab",  d: "Z", ack: false },
-      { id: 4, t: "clin", d: "W", ack: false },
+      { id: 2, t: "lab",  d: "Y", ack: false, sev: "md" as const },
+      { id: 3, t: "lab",  d: "Z", ack: false, sev: "md" as const },
+      { id: 4, t: "clin", d: "W", ack: false, sev: "md" as const },
     ]});
     expect(selectFila3(makeState([p1, p2, p3])).map((p) => p.id)).toEqual([1, 3]);
   });


### PR DESCRIPTION
## Summary

- `InstItem.sev` alterado de opcional para required; fallback `"md"` na normalização para backend que omite o campo
- `INST_STYLE` no `PatientCard` re-keyed por `sev` (`cr/al/md/bx`) com cores corretas por severidade
- Label "Campo 3 – Instabilidade" no card exibe a cor da maior severidade entre os alertas ativos (indicador agregado RF12)
- `INST_DOT_COLOR` no `PatientModal` re-keyed por `sev`; 3 ocorrências de `item.t` corrigidas para `item.sev`
- `INST_TYPE_LABEL` mantido por `t` — tipo do gatilho (Laboratório/Clínico/Prescrição) não muda

## Test plan

- [ ] Paciente com alerta `sev = cr` → chip vermelho no card
- [ ] Paciente com alerta `sev = al` → chip laranja no card
- [ ] Paciente com alerta `sev = md` → chip roxo no card
- [ ] Label "Campo 3 – Instabilidade" reflete cor do alerta mais grave
- [ ] Tab Instabilidade no modal: dot color por severidade, type label (Laboratório/Clínico/Prescrição) inalterado
- [ ] Backend sem campo `sev` → fallback `"md"` sem crash
- [ ] Build TypeScript sem erros (`npx tsc --noEmit`)