### PR TITLE
fix(rf16): clear d7 flag on assessment save

### DIFF
--- a/src/features/nutritional/NutritionalSlice.ts
+++ b/src/features/nutritional/NutritionalSlice.ts
@@ -460,6 +460,7 @@ const nutritionalSlice = createSlice({
         if (patient) {
           patient.haval = 0;
           patient.conduta = conduta;
+          patient.d7 = false;
           const now = new Date();
           const dd = String(now.getDate()).padStart(2, "0");
           const mm = String(now.getMonth() + 1).padStart(2, "0");


### PR DESCRIPTION
## Summary

- `saveAvalToServer.fulfilled` agora seta `patient.d7 = false` após avaliação salva com sucesso
- Alinha com RF18: D7 encerrado automaticamente ao registrar avaliação
- Completa o fluxo RF16: usuário seleciona "Sim – antecipar" na tab Instabilidade → redireciona para tab Avaliação → salva assessment → badge D7 some do card

## Comportamento anterior

Badge D7 permanecia no card mesmo após salvar avaliação — só desaparecia no próximo `fetchPatients` (polling de 3 min).

## Test plan

- [ ] Paciente com badge D7 → salvar avaliação → badge D7 desaparece imediatamente do card
- [ ] Selecionar "Sim – antecipar" na tab Instabilidade → redireciona para tab Avaliação
- [ ] Salvar avaliação após antecipação → D7 limpo + `haval = 0` + entrada no histórico
- [ ] Selecionar "Não – manter programação" → D7 permanece até próximo fetch