### PR TITLE
fix(dashboard): show 'Sem avaliação' when haval is null + modal live state

### DIFF
--- a/src/features/nutritional/NutritionalDashboard.tsx
+++ b/src/features/nutritional/NutritionalDashboard.tsx
@@ -67,7 +67,10 @@ export function NutritionalDashboard() {
   const [filtSev, setFiltSev] = useState("");
   const [sortAsc, setSortAsc] = useState(false);
   const [modalTab, setModalTab] = useState("vis");
-  const [modalPatient, setModalPatient] = useState<NutritionalPatient | null>(null);
+  const [modalPatientId, setModalPatientId] = useState<number | null>(null);
+  const modalPatient = modalPatientId !== null
+    ? (patients.find((p: NutritionalPatient) => p.id === modalPatientId) ?? null)
+    : null;
   const [showChumlea, setShowChumlea] = useState(false);
 
 
@@ -127,7 +130,7 @@ export function NutritionalDashboard() {
   };
 
   const handleOpenTab = (patient: NutritionalPatient, tab: string) => {
-    setModalPatient(patient);
+    setModalPatientId(patient.id);
     setModalTab(tab);
   };
 
@@ -336,12 +339,11 @@ export function NutritionalDashboard() {
                     const isAtend = !!acknowledged[p.id];
                     const sevCfg = p.sev ? SEV_CONFIG[p.sev] : SEV_CONFIG["bx"];
                     const isUTI = p.ala === "UTI";
-                    const havalColor =
-                      p.haval > 48
-                        ? "#c41e3a"
-                        : p.haval > 24
-                          ? "#d4931a"
-                          : "#3a9c6e";
+                    const havalNever = p.haval >= 999;
+                    const havalColor = havalNever ? "#c41e3a"
+                      : p.haval > 48 ? "#c41e3a"
+                      : p.haval > 24 ? "#d4931a"
+                      : "#3a9c6e";
 
                     const instTags = p.inst.slice(0, 3);
                     const instMore = p.inst.length > 3 ? p.inst.length - 3 : 0;
@@ -552,7 +554,7 @@ export function NutritionalDashboard() {
                           </span>
                           <span style={{ display: "flex", alignItems: "center", gap: 4 }}>
                             <ClockCircleOutlined style={{ color: havalColor }} />
-                            <span style={{ color: havalColor }}>{p.haval}h s/ avaliação</span>
+                            <span style={{ color: havalColor }}>{havalNever ? "Sem avaliação" : `${p.haval}h s/ aval.`}</span>
                           </span>
                           {p.alergia && (
                             <InlineBadge
@@ -593,7 +595,7 @@ export function NutritionalDashboard() {
         acknowledged={acknowledged}
         activeTab={modalTab}
         onTabChange={setModalTab}
-        onClose={() => setModalPatient(null)}
+        onClose={() => setModalPatientId(null)}
       />
     </>
   );

--- a/src/features/nutritional/NutritionalDashboard.tsx
+++ b/src/features/nutritional/NutritionalDashboard.tsx
@@ -7,6 +7,7 @@ import {
   Segmented,
   Spin,
   Tooltip,
+  message,
 } from "antd";
 import {
   AppstoreOutlined,
@@ -80,6 +81,14 @@ export function NutritionalDashboard() {
     const interval = setInterval(() => dispatch(fetchPatients({})), REFRESH_INTERVAL);
     return () => clearInterval(interval);
   }, [dispatch]);
+
+  // ── Close modal gracefully if patient removed from polling ──────────────
+  useEffect(() => {
+    if (modalPatientId !== null && modalPatient === null) {
+      message.warning("Paciente não encontrado — pode ter recebido alta ou sido transferido.");
+      setModalPatientId(null);
+    }
+  }, [modalPatient, modalPatientId]);
 
   // ── Filtered + sorted list ──────────────────────────────────────────────
   // matchFila is a pure module-level function — no closure, not a dep.

--- a/src/features/nutritional/components/PatientModal/PatientModal.tsx
+++ b/src/features/nutritional/components/PatientModal/PatientModal.tsx
@@ -150,8 +150,9 @@ export function PatientModal({
   const mnSev = p.mnutric != null ? sevMNUTRIC(p.mnutric) : null;
   const nrsSev = sevNRS(p.nrs);
 
-  const havalColor =
-    p.haval > 48 ? "#c41e3a" : p.haval > 24 ? "#d4931a" : "#3a9c6e";
+  const havalNever = p.haval >= 999;
+  const havalColor = havalNever ? "#c41e3a"
+    : p.haval > 48 ? "#c41e3a" : p.haval > 24 ? "#d4931a" : "#3a9c6e";
 
   // NRS real-time score
   const nrsPreview = nrsA + p.nrs_dims.doenca + (p.idade >= 70 ? 1 : 0);
@@ -488,7 +489,7 @@ export function PatientModal({
           <InfoBlock>
             <div className="info-label">Última avaliação</div>
             <div className="info-value" style={{ color: havalColor }}>
-              <ClockCircleOutlined /> {p.haval}h atrás
+              <ClockCircleOutlined /> {havalNever ? "Sem avaliação registrada" : `${p.haval}h atrás`}
             </div>
           </InfoBlock>
         </Col>


### PR DESCRIPTION
## Summary

- `haval = null` do backend normaliza para sentinel `999`; display agora mostra **"Sem avaliação registrada"** em vez de "999h atrás" no modal e na view de lista
- `modalPatient` derivado do store por ID em vez de `useState` snapshot — atualizações de `hist`, `haval` e `d7` via thunks refletem imediatamente no modal sem fechar e reabrir

## Root cause

`normalizeApiPatient` usa `raw.haval ?? 999` como sentinel para "nunca avaliado". O backend confirma: 18 dos 28 pacientes retornam `haval: null`. O frontend exibia o número cru `999h atrás`.

## Test plan

- [ ] Paciente sem avaliação → exibe "Sem avaliação registrada" no modal (aba Resumo) e "Sem avaliação" na lista
- [ ] Paciente com `haval = 7.1` → exibe "7.1h atrás" normalmente
- [ ] Salvar avaliação → histórico aparece no modal sem fechar e reabrir
- [ ] Badge D7 some do card imediatamente após salvar avaliação