### PR TITLE
fix: refetch alerts after acknowledge and fix error detection

### DIFF
--- a/src/features/nutritional/components/PatientModal/PatientModal.tsx
+++ b/src/features/nutritional/components/PatientModal/PatientModal.tsx
@@ -233,26 +233,32 @@ export function PatientModal({
 
   const handleAcknowledgeAlert = async (alertId: number) => {
     dispatch(markAlertAcknowledged({ patientId: p.id, alertId }));
-    try {
-      await dispatch(acknowledgeAlert({ patientId: p.id, alertId })).unwrap();
-    } catch {
+    const result = await dispatch(acknowledgeAlert({ patientId: p.id, alertId }));
+    if (acknowledgeAlert.rejected.match(result)) {
+      console.error("acknowledgeAlert rejected:", result.payload ?? result.error);
       dispatch(revertAlert({ patientId: p.id, alertId }));
       message.error("Erro ao reconhecer alerta.");
+    } else {
+      dispatch(fetchAlerts(p.id));
     }
   };
 
   const handleAcknowledgeAll = async () => {
     const activeAlerts = p.inst.filter((i) => !i.ack);
+    let failed = false;
     for (const alert of activeAlerts) {
       dispatch(markAlertAcknowledged({ patientId: p.id, alertId: alert.id }));
-      try {
-        await dispatch(acknowledgeAlert({ patientId: p.id, alertId: alert.id })).unwrap(); // eslint-disable-line no-await-in-loop
-      } catch {
+      // eslint-disable-next-line no-await-in-loop
+      const result = await dispatch(acknowledgeAlert({ patientId: p.id, alertId: alert.id }));
+      if (acknowledgeAlert.rejected.match(result)) {
+        console.error("acknowledgeAlert rejected:", result.payload ?? result.error);
         dispatch(revertAlert({ patientId: p.id, alertId: alert.id }));
         message.error("Erro ao reconhecer alertas.");
+        failed = true;
         break;
       }
     }
+    if (!failed) dispatch(fetchAlerts(p.id));
   };
 
   // ── Tab: Resumo ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Replace `unwrap()`/`try-catch` with `rejected.match()` to avoid false-positive error handling on successful 200 responses
- Dispatch `fetchAlerts` after each successful individual acknowledge so `inst` list reflects server state
- Fix `handleAcknowledgeAll` to only refetch when all acknowledges succeed (previously refetched even after partial failure with `break`)

## Test plan

- [ ] Acknowledge individual alert → alert desaparece da lista, sem mensagem de erro
- [ ] Acknowledge todos os alertas → lista fica vazia, sem mensagem de erro
- [ ] Simular falha de rede → mensagem de erro exibida, alerta reverte para tela
- [ ] Verificar console: sem logs `acknowledgeAlert rejected:` em fluxo normal