### PR TITLE
fix: card severity reflects max between inst alerts and triage sev

### DIFF
--- a/src/features/nutritional/components/PatientCard/PatientCard.tsx
+++ b/src/features/nutritional/components/PatientCard/PatientCard.tsx
@@ -70,7 +70,7 @@ export function PatientCard({
     : null;
 
   return (
-    <Card $sev={maxInstSev != null && SEV_ORDER[maxInstSev] > SEV_ORDER[p.sev] ? maxInstSev : p.sev} $atend={isAtend}>
+    <Card $sev={maxInstSev != null && SEV_ORDER[maxInstSev] > SEV_ORDER[p.sev ?? "bx"] ? maxInstSev : p.sev} $atend={isAtend}>
       <CardBody onClick={onClick}>
         <CardTop>
           <BedLabel>{p.leito}</BedLabel>

--- a/src/features/nutritional/components/PatientCard/PatientCard.tsx
+++ b/src/features/nutritional/components/PatientCard/PatientCard.tsx
@@ -70,7 +70,7 @@ export function PatientCard({
     : null;
 
   return (
-    <Card $sev={maxInstSev ?? p.sev} $atend={isAtend}>
+    <Card $sev={maxInstSev != null && SEV_ORDER[maxInstSev] > SEV_ORDER[p.sev] ? maxInstSev : p.sev} $atend={isAtend}>
       <CardBody onClick={onClick}>
         <CardTop>
           <BedLabel>{p.leito}</BedLabel>


### PR DESCRIPTION
## Summary
- `PatientCard` usava `maxInstSev ?? p.sev`, sobrescrevendo a severidade da triagem quando havia alertas ativos — mesmo que `p.sev` fosse maior
- Exemplo do bug: paciente com `sev=cr` e alerta `inst=al` exibia card laranja em vez de vermelho
- Fix: compara os dois com `SEV_ORDER` e usa o maior

## Test plan
- [ ] Paciente com `sev=cr` e alerta `inst=al` → card vermelho
- [ ] Paciente sem alertas ativos → card usa `p.sev` normalmente
- [ ] Paciente com alerta `inst=cr` e `sev=al` → card vermelho (alerta vence)