### PR TITLE
fix: card severity reflects max between inst alerts and triage sev

### DIFF
--- a/src/features/nutritional/components/PatientCard/PatientCard.tsx
+++ b/src/features/nutritional/components/PatientCard/PatientCard.tsx
@@ -70,7 +70,7 @@ export function PatientCard({
     : null;
 
   return (
-    <Card $sev={maxInstSev != null && SEV_ORDER[maxInstSev] > SEV_ORDER[p.sev] ? maxInstSev : p.sev} $atend={isAtend}>
+    <Card $sev={maxInstSev != null && SEV_ORDER[maxInstSev] > SEV_ORDER[p.sev ?? "bx"] ? maxInstSev : p.sev} $atend={isAtend}>
       <CardBody onClick={onClick}>
         <CardTop>
           <BedLabel>{p.leito}</BedLabel>

--- a/src/features/nutritional/components/PatientCard/PatientCard.tsx
+++ b/src/features/nutritional/components/PatientCard/PatientCard.tsx
@@ -70,7 +70,7 @@ export function PatientCard({
     : null;
 
   return (
-    <Card $sev={maxInstSev ?? p.sev} $atend={isAtend}>
+    <Card $sev={maxInstSev != null && SEV_ORDER[maxInstSev] > SEV_ORDER[p.sev] ? maxInstSev : p.sev} $atend={isAtend}>
       <CardBody onClick={onClick}>
         <CardTop>
           <BedLabel>{p.leito}</BedLabel>


### PR DESCRIPTION
## Summary
- `PatientCard` usava `maxInstSev ?? p.sev`, sobrescrevendo a severidade da triagem quando havia alertas ativos — mesmo que `p.sev` fosse maior
- Exemplo: paciente com `sev=cr` e alerta `inst=al` exibia card laranja em vez de vermelho
- Fix: compara os dois com `SEV_ORDER` e usa o maior; trata `p.sev=null` com fallback `"bx"`

## Commits
- `d43ea509` fix: card severity now reflects max between inst alerts and triage sev
- `0f7614b5` fix: handle null p.sev in SEV_ORDER index lookup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ajustado o destaque visual de severidade em cartões de pacientes para priorizar corretamente a condição mais relevante.
  * Quando houver instabilidades, o nível exibido agora respeita melhor a ordem de severidade, evitando realces inconsistentes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->