### PR TITLE
fix: FILA3 e FILA4 filtram corretamente (alerta crítico e desnut. grave)

### DIFF
--- a/src/features/nutritional/NutritionalDashboard.tsx
+++ b/src/features/nutritional/NutritionalDashboard.tsx
@@ -29,7 +29,6 @@ import {
   setFiltFila as setFiltFilaAction,
   NutritionalPatient,
   AlaType,
-  AcknowledgedEntry,
 } from "./NutritionalSlice";
 import { NutritionalFilter } from "./components/NutritionalFIlter/NutritionalFilter";
 import { PatientCard } from "./components/PatientCard/PatientCard";
@@ -45,6 +44,7 @@ import {
   getPatientScore,
   scoreColorMnutric,
   scoreColorNrs,
+  matchFila,
 } from "./nutritionalUtils";
 import { SummaryBar, SummaryItem, SummaryRight, WardSection, WardHeader, WardLeft, WardDot, WardName, WardSub, BedGrid, EmptyBed, ListCard, ListCardBody, ListCell, ListCellLabel, InlineBadge, ListCardFooter } from "./styles";
 
@@ -108,7 +108,7 @@ export function NutritionalDashboard() {
       list = list.filter((p) => p.alergia !== null && !p.alOk);
     }
     if (filtFila) {
-      list = list.filter((p) => matchFila(p, filtFila, acknowledged));
+      list = list.filter((p) => matchFila(p, filtFila));
     }
     return list.sort((a, b) =>
       sortAsc
@@ -136,28 +136,6 @@ export function NutritionalDashboard() {
     com: patients.filter((p: NutritionalPatient) => p.alergia !== null).length,
     pendente: patients.filter((p: NutritionalPatient) => p.alergia !== null && !p.alOk).length,
   }), [patients]);
-
-  function matchFila(
-    p: NutritionalPatient,
-    filtFila: string,
-    _acknowledged: Record<number, AcknowledgedEntry>
-  ): boolean {
-    if (!filtFila || filtFila === "all") return true;
-    if (filtFila === "FILA1") return (p.sev === "cr" || p.sev === "al") && p.haval > 18;
-    if (filtFila === "FILA2") {
-      if (p.haval === null || p.haval === 0) return false;
-      // freq_horas = 48, haval = 40 (>= 48*0.8=38.4) → Fila 2 inclui
-      // freq_horas = 48, haval = 30 (< 38.4) → Fila 2 exclui
-      // freq_horas = null, haval = 15 → fallback inclui (12–24h)
-      // freq_horas = null, haval = 30 → fallback exclui
-      if ((p as any).freq_horas != null) {
-        return p.haval >= (p as any).freq_horas * 0.8;
-      }
-      return p.haval >= 12 && p.haval <= 24;
-    }
-    if (filtFila === "FILA5") return p.d7 === true;
-    return true;
-  };
 
   const handleAcknowledge = (id: number) => {
     dispatch(


### PR DESCRIPTION
## Resumo
- Filtros FILA3 (alerta crítico) e FILA4 (desnut. grave) exibiam todos os pacientes em vez do subconjunto correto
- Causa: `matchFila` local no dashboard não tratava esses casos, caindo em `return true`
- Fix: removida função local, usando `matchFila` de `nutritionalUtils` (mesma usada pelos seletores Redux)

## Commits
- `7847bb2d` fix: use shared matchFila from nutritionalUtils to fix FILA3/FILA4 filter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ajustada a filtragem do painel nutricional para usar uma lógica mais consistente, melhorando os resultados exibidos ao aplicar filtros.
  * Removido um critério extra de filtragem que não era mais necessário, mantendo a experiência mais previsível ao navegar pelos itens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->