### PR TITLE
feat: painel de indicadores de triagem

### DIFF
--- a/src/features/nutritional/NutritionalDashboard.tsx
+++ b/src/features/nutritional/NutritionalDashboard.tsx
@@ -34,6 +34,7 @@ import { NutritionalFilter } from "./components/NutritionalFIlter/NutritionalFil
 import { PatientCard } from "./components/PatientCard/PatientCard";
 import { PatientModal } from "./components/PatientModal/PatientModal";
 import { ChumleaCalculator } from "./components/ChumleaCalculator/ChumleaCalculator";
+import { TriagemIndicatorsBar } from "./components/TriagemIndicators/TriagemIndicatorsBar";
 import {
   REFRESH_INTERVAL,
   SEV_CONFIG,
@@ -225,6 +226,8 @@ export function NutritionalDashboard() {
         onFilaChange={(val) => dispatch(setFiltFilaAction(val))}
         onSortToggle={() => setSortAsc((v) => !v)}
       />
+
+      <TriagemIndicatorsBar ala={filtAla} />
 
       {/* Summary bar */}
       <SummaryBar>

--- a/src/features/nutritional/components/TriagemIndicators/TriagemIndicatorsBar.tsx
+++ b/src/features/nutritional/components/TriagemIndicators/TriagemIndicatorsBar.tsx
@@ -1,0 +1,145 @@
+import { useEffect, useState } from "react";
+import { Spin, Tooltip } from "antd";
+import { InfoCircleOutlined } from "@ant-design/icons";
+import styled from "styled-components";
+import api, { TriagemIndicatorsData, TriagemIndicatorsParams } from "services/nutritional/api";
+
+const Bar = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0;
+  overflow-x: auto;
+  background: #fff;
+  border: 1px solid #f0f0f0;
+  border-radius: 8px;
+  margin-bottom: 16px;
+  padding: 0;
+  scrollbar-width: none;
+  &::-webkit-scrollbar { display: none; }
+`;
+
+const Label = styled.div`
+  padding: 10px 16px;
+  border-right: 1px solid #f0f0f0;
+  font-size: 11px;
+  font-weight: 700;
+  color: #2e3c5a;
+  white-space: nowrap;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+`;
+
+const Stat = styled.div<{ $color: string }>`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 10px 20px;
+  border-right: 1px solid #f0f0f0;
+  white-space: nowrap;
+  flex-shrink: 0;
+
+  .val {
+    font-size: 20px;
+    font-weight: 700;
+    line-height: 1;
+    color: ${(p) => p.$color};
+  }
+  .lbl {
+    font-size: 10px;
+    color: #8c8c8c;
+    margin-top: 2px;
+  }
+`;
+
+const BigPct = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 10px 24px;
+  border-right: 1px solid #f0f0f0;
+  flex-shrink: 0;
+
+  .pct {
+    font-size: 20px;
+    font-weight: 700;
+    line-height: 1;
+    color: #3a9c6e;
+  }
+  .lbl {
+    font-size: 10px;
+    color: #8c8c8c;
+    margin-top: 2px;
+  }
+`;
+
+interface Props {
+  ala?: string;
+}
+
+export function TriagemIndicatorsBar({ ala }: Props) {
+  const [data, setData] = useState<TriagemIndicatorsData | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    setLoading(true);
+    const params: TriagemIndicatorsParams = {};
+    if (ala && ala !== "all") params.ala = ala;
+
+    api.nutritional.getTriagemIndicators(params)
+      .then((res: any) => setData(res.data?.data ?? null))
+      .catch(() => setData(null))
+      .finally(() => setLoading(false));
+  }, [ala]);
+
+  return (
+    <Bar>
+      <Label>
+        Triagem
+        <Tooltip title="% pacientes triados em ≤24h da internação no período atual">
+          <InfoCircleOutlined style={{ color: "#8c8c8c", fontSize: 12 }} />
+        </Tooltip>
+      </Label>
+
+      {loading && (
+        <div style={{ padding: "10px 20px" }}>
+          <Spin size="small" />
+        </div>
+      )}
+
+      {!loading && data && (
+        <>
+          <BigPct>
+            <span className="pct">{data.percentual.toFixed(1)}%</span>
+            <span className="lbl">triados ≤24h</span>
+          </BigPct>
+          <Stat $color="#3a9c6e">
+            <span className="val">{data.verde}</span>
+            <span className="lbl">≤24h</span>
+          </Stat>
+          <Stat $color="#c41e3a">
+            <span className="val">{data.vermelho}</span>
+            <span className="lbl">&gt;24h</span>
+          </Stat>
+          <Stat $color="#8c8c8c">
+            <span className="val">{data.cinza}</span>
+            <span className="lbl">sem triagem</span>
+          </Stat>
+          <Stat $color="#2e3c5a">
+            <span className="val">{data.total}</span>
+            <span className="lbl">total admitidos</span>
+          </Stat>
+        </>
+      )}
+
+      {!loading && !data && (
+        <div style={{ padding: "10px 16px", fontSize: 12, color: "#8c8c8c" }}>
+          Sem dados de triagem
+        </div>
+      )}
+    </Bar>
+  );
+}

--- a/src/services/nutritional/api.ts
+++ b/src/services/nutritional/api.ts
@@ -133,7 +133,7 @@ export interface AvalPayload {
 
 
 api.nutritional.getTriagemIndicators = (params?: TriagemIndicatorsParams) =>
-  instance.get('/nutritional/triagem-indicators', {
+  instance.get('/nutritional/indicators', {
     params,
     ...setHeaders(),
   });

--- a/src/services/nutritional/api.ts
+++ b/src/services/nutritional/api.ts
@@ -1,6 +1,21 @@
 import apiModule, { instance, setHeaders } from '../api';
 
 
+export interface TriagemIndicatorsParams {
+  setor?: number;
+  ala?: string;
+  start_date?: string;
+  end_date?: string;
+}
+
+export interface TriagemIndicatorsData {
+  percentual: number;
+  total: number;
+  verde: number;
+  vermelho: number;
+  cinza: number;
+}
+
 interface NutritionalAPI {
   getPatients: (params?: { setor?: number; ala?: string }) => any;
   saveNrsNut: (nratendimento: number, data: NrsNutPayload) => any;
@@ -9,6 +24,7 @@ interface NutritionalAPI {
   acknowledgePatient: (nratendimento: number) => any;
   getAlerts: (nratendimento: number) => any;
   acknowledgeAlert: (nratendimento: number, alertId: number) => any;
+  getTriagemIndicators: (params?: TriagemIndicatorsParams) => any;
 };
 
 
@@ -115,6 +131,12 @@ export interface AvalPayload {
   meta_prot?: number;
 };
 
+
+api.nutritional.getTriagemIndicators = (params?: TriagemIndicatorsParams) =>
+  instance.get('/nutritional/triagem-indicators', {
+    params,
+    ...setHeaders(),
+  });
 
 api.nutritional.getAlerts = (nratendimento: number) =>
   instance.get(`/nutritional/patients/${nratendimento}/alerts`, setHeaders());


### PR DESCRIPTION
## O que foi feito
Novo componente `TriagemIndicatorsBar` exibido acima da SummaryBar no dashboard nutricional.

Consome `GET /nutritional/indicators` e exibe:
- **%** triados em ≤24h da internação
- Contagem **verde** (≤24h), **vermelho** (>24h), **cinza** (sem triagem)
- **Total** admitidos no período

Sincroniza automaticamente com o filtro de ala já existente no dashboard.

## Parâmetros da API
```
GET /nutritional/indicators
  ?ala=UTI          (sincronizado com filtro de ala)
  ?setor=10         (opcional)
  ?start_date=...   (opcional)
  ?end_date=...     (opcional)
```

## Test plan
- [ ] Indicadores aparecem no topo do painel
- [ ] Ao mudar filtro de ala, números atualizam
- [ ] Loading exibido durante fetch
- [ ] Sem dados → mensagem "Sem dados de triagem"