### PR TITLE
feat: persist NRS-2002 component A via backend endpoint

### DIFF
--- a/src/features/nutritional/NutritionalSlice.ts
+++ b/src/features/nutritional/NutritionalSlice.ts
@@ -197,6 +197,25 @@ export const saveMnutricManual = createAsyncThunk(
   }
 );
 
+export const saveNrsNutA = createAsyncThunk(
+  "nutritional/saveNrsNutA",
+  async ({ id, nut }: { id: number; nut: number }, thunkAPI) => {
+    try {
+      const response = await api.nutritional.saveNrsA(id, { nut });
+      const d = response.data?.data ?? response.data ?? {};
+      return { id, nrs_nut: d.nrs_nut, nrs_doenca: d.nrs_doenca, nrs_idade: d.nrs_idade, nrs_total: d.nrs_total, classificacao: d.classificacao, nrs_completo: d.nrs_completo };
+    } catch (err) {
+      const axiosErr = err as AxiosError<{ error?: string; message?: string }>;
+      return thunkAPI.rejectWithValue(
+        axiosErr.response?.data?.error ??
+        axiosErr.response?.data?.message ??
+        axiosErr.message ??
+        "Erro ao salvar NRS-A"
+      );
+    }
+  }
+);
+
 export const fetchAlerts = createAsyncThunk(
   "nutritional/fetchAlerts",
   async (patientId: number, thunkAPI) => {
@@ -453,6 +472,19 @@ const nutritionalSlice = createSlice({
           patient.sev = campo1.classificacao ?? patient.sev;
           patient.mn_dims = campo1.mn_dims ?? patient.mn_dims;
           patient.nrs_completo = campo1.nrs_completo ?? patient.nrs_completo;
+        }
+      })
+      .addCase(saveNrsNutA.fulfilled, (state, action) => {
+        const { id, nrs_nut, nrs_doenca, nrs_idade, nrs_total, classificacao, nrs_completo } = action.payload;
+        const patient = state.patients.find((p) => p.id === id);
+        if (patient) {
+          patient.nrs_dims.nut = nrs_nut ?? patient.nrs_dims.nut;
+          patient.nrs_dims.doenca = nrs_doenca ?? patient.nrs_dims.doenca;
+          patient.nrs_dims.idade = nrs_idade ?? patient.nrs_dims.idade;
+          patient.nrs = nrs_total ?? patient.nrs;
+          patient.sev = classificacao ?? patient.sev;
+          patient.nrs_completo = nrs_completo;
+          if (nrs_completo) patient.triagem_status = "finalizada";
         }
       })
       .addCase(saveGlimToServer.fulfilled, (state, action) => {

--- a/src/features/nutritional/NutritionalSlice.ts
+++ b/src/features/nutritional/NutritionalSlice.ts
@@ -1,6 +1,7 @@
 import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
 import { AxiosError } from "axios";
-import api, { instance, setHeaders } from "services/api";
+import api from "services/nutritional/api";
+import { instance, setHeaders } from "services/api";
 
 export type AlaType = "UTI" | "B" | "C";
 export type SeverityType = "cr" | "al" | "md" | "bx";

--- a/src/features/nutritional/components/PatientModal/PatientModal.tsx
+++ b/src/features/nutritional/components/PatientModal/PatientModal.tsx
@@ -24,7 +24,6 @@ import {
   NutritionalPatient,
   AcknowledgedEntry,
   GlimDiag,
-  saveNrsNut,
   saveNrsNutA,
   confirmAllergy,
   acknowledgePatient,

--- a/src/features/nutritional/components/PatientModal/PatientModal.tsx
+++ b/src/features/nutritional/components/PatientModal/PatientModal.tsx
@@ -25,6 +25,7 @@ import {
   AcknowledgedEntry,
   GlimDiag,
   saveNrsNut,
+  saveNrsNutA,
   confirmAllergy,
   acknowledgePatient,
   markAlertAcknowledged,
@@ -207,8 +208,13 @@ export function PatientModal({
     }
   };
 
-  const handleSaveNrs = () => {
-    dispatch(saveNrsNut({ id: p.id, nut: nrsA }));
+  const handleSaveNrs = async () => {
+    const result = await dispatch(saveNrsNutA({ id: p.id, nut: nrsA }));
+    if (saveNrsNutA.fulfilled.match(result)) {
+      message.success("NRS-2002 salvo com sucesso.");
+    } else {
+      message.error(`Erro ao salvar NRS-2002: ${(result as any).payload ?? "erro desconhecido"}`); // eslint-disable-line @typescript-eslint/no-explicit-any
+    }
   };
 
   const handleSaveAval = async () => {

--- a/src/services/nutritional/api.ts
+++ b/src/services/nutritional/api.ts
@@ -19,6 +19,7 @@ export interface TriagemIndicatorsData {
 interface NutritionalAPI {
   getPatients: (params?: { setor?: number; ala?: string }) => any;
   saveNrsNut: (nratendimento: number, data: NrsNutPayload) => any;
+  saveNrsA: (nratendimento: number, data: { nut: number }) => any;
   saveGlim: (nratendimento: number, data: GlimPayload) => any;
   saveAval: (nratendimento: number, data: AvalPayload) => any;
   acknowledgePatient: (nratendimento: number) => any;
@@ -62,6 +63,20 @@ api.nutritional.getPatients = (params?: { setor?: number; ala?: string }) =>
 api.nutritional.saveNrsNut = (nratendimento: number, data: NrsNutPayload) =>
   instance.put(
     `/nutritional/patients/${nratendimento}/nrs-nut`,
+    data,
+    setHeaders(),
+  );
+
+/**
+ * Saves manual Component A (nutritional status) of NRS-2002.
+ * Returns recalculated NRS totals and updated classification.
+ * @param nratendimento - Patient admission number
+ * @param data - Payload with nut score (0–3)
+ * @returns Promise with updated NRS breakdown and classification
+ */
+api.nutritional.saveNrsA = (nratendimento: number, data: { nut: number }) =>
+  instance.put(
+    `/nutritional/patients/${nratendimento}/nrs-a`,
     data,
     setHeaders(),
   );


### PR DESCRIPTION
## Summary

- Add `saveNrsA` to nutritional API service (`PUT /nutritional/patients/{id}/nrs-a`)
- Add `saveNrsNutA` async thunk with try/catch and `rejectWithValue` error handling
- Update `extraReducers` fulfilled case to sync `nrs_dims`, `nrs`, `sev`, `nrs_completo`, and `triagem_status` from backend response
- Replace synchronous `dispatch(saveNrsNut(...))` with async `dispatch(saveNrsNutA(...))` in `handleSaveNrs`, with `message.success/error` feedback

## Test plan

- [ ] Open patient card (non-UTI) → NRS tab visible
- [ ] Change component A dropdown value → preview score updates in real time
- [ ] Click "Salvar NRS-2002" → success toast appears
- [ ] Reopen modal → saved value persists (loaded from backend)
- [ ] Verify `patient.sev` and `triagem_status` update correctly when `nrs_completo = true`
- [ ] Verify error toast on invalid value or network failure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Novas funcionalidades**
  * Salvamento do NRS-2002 agora é confirmado de forma assíncrona, com retorno de sucesso ou falha para o usuário.
  * O status nutricional do paciente é atualizado automaticamente após o salvamento, incluindo pontuação, classificação e conclusão da triagem.

* **Correções**
  * Melhor tratamento de erros ao salvar o NRS-2002, evitando avançar sem validação adequada.
  * Fluxo de triagem atualizado para marcar a avaliação como finalizada quando os dados estiverem completos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->