### PR TITLE
fix: corrige endpoint de salvamento do mNUTRIC manual (de /nrs-nut para /mnutric-manual)

### DIFF
--- a/src/features/nutritional/NutritionalSlice.ts
+++ b/src/features/nutritional/NutritionalSlice.ts
@@ -182,7 +182,7 @@ export const saveMnutricManual = createAsyncThunk(
     thunkAPI
   ) => {
     try {
-      const response = await instance.put(`/nutritional/patients/${id}/nrs-nut`, { apache_ii, sofa }, setHeaders());
+      const response = await instance.put(`/nutritional/patients/${id}/mnutric-manual`, { apache_ii, sofa }, setHeaders());
       const campo1 = response.data?.campo1 ?? response.data ?? {};
       return { id, campo1 };
     } catch (err) {


### PR DESCRIPTION
Ao tentar salvar o formulário com os dados de APACHE II e SOFA (mNUTRIC) para pacientes de UTI, a aplicação estava quebrando e recebendo um erro HTTP 500.

Durante a refatoração recente que inlinou as chamadas de API (substituindo api.nutritional.X por chamadas diretas no Axios), a action saveMnutricManual acabou herdando o endpoint /nrs-nut de um código antigo e órfão. Essa rota não existe no backend atual.

Foi corrigida a rota apontada pelo saveMnutricManual no NutritionalSlice.ts.

De: PUT /nutritional/patients/{id}/nrs-nut ❌
Para: PUT /nutritional/patients/{id}/mnutric-manual ✅